### PR TITLE
Fix download link to use zip path not search id

### DIFF
--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -12,6 +12,7 @@ from arches.app.models import models
 from arches.app.search.search_export import SearchResultsExporter
 import arches.app.utils.zip as zip_utils
 from django.utils.translation import ugettext as _
+from django.conf import settings
 
 
 @shared_task
@@ -66,6 +67,8 @@ def export_search_results(self, userid, request_values, format):
     exporter = SearchResultsExporter(search_request=new_request)
     files, export_info = exporter.export(format)
     exportid = exporter.write_export_zipfile(files, export_info)
+    search_history_obj = models.SearchExportHistory.objects.get(pk=exportid)
+
 
     context = dict(
         greeting="Hello,\nYour request to download a set of search results is now ready.",
@@ -74,6 +77,7 @@ def export_search_results(self, userid, request_values, format):
         closing="Thank you",
         email=email,
         name=export_name,
+        email_link=str(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT) + "/files/" + str(search_history_obj.downloadfile),
     )
     response = {"taskid": self.request.id, "msg": export_name, "notiftype_name": "Search Export Download Ready", "context": context}
 

--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -12,7 +12,7 @@ from arches.app.models import models
 from arches.app.search.search_export import SearchResultsExporter
 import arches.app.utils.zip as zip_utils
 from django.utils.translation import ugettext as _
-from django.conf import settings
+from arches.app.models.system_settings import settings
 
 
 @shared_task

--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -77,7 +77,7 @@ def export_search_results(self, userid, request_values, format):
         closing="Thank you",
         email=email,
         name=export_name,
-        email_link=str(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT) + "/files/" + str(search_history_obj.downloadfile),
+        email_link=str(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT).rstrip("/") + "/files/" + str(search_history_obj.downloadfile),
     )
     response = {"taskid": self.request.id, "msg": export_name, "notiftype_name": "Search Export Download Ready", "context": context}
 

--- a/arches/app/templates/email/download_ready_email_notification.htm
+++ b/arches/app/templates/email/download_ready_email_notification.htm
@@ -7,7 +7,7 @@
 <body style="width: 400px;">
     <p>{{greeting}}</p>
     {% if link != "" %}
-    <a class="btn" href="{{link}}"><button class='btn btn-notifs-download btn-labeled btn-sm fa fa-download'>{{button_text}}</button></a>
+    <a class="btn" href="{{email_link}}"><button class='btn btn-notifs-download btn-labeled btn-sm fa fa-download'>{{button_text}}</button></a>
     {% endif %}
     <p>{{closing}}</p>
 </body>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
The correct URL to the zip file for downloaded needed to be injected into the download_ready_email_notification.htm template for emailing to the user.
The zip file path as stored in the database was obtained using the exportid and then this was appended to a concatenated string created from the Arches Namespace (as designated in the application's settings file) and /files/.  I have run the exported locally and the correct path is now produced.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
The download link injected into the download_ready_email_notification.htm template only had the searchexportid value of the search, not the path to the zip file.  The correct zip file path is now injected.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
