### PR TITLE
Bug 24677: Best effort to fix NVDA issues

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -4839,6 +4839,7 @@ ul.jqtree_common li.jqtree-folder {
 .top-right-nav {
     display: flex;
     float: right;
+    margin-right: -8px;
 }
 
 .top-right-nav .top-btn-container {
@@ -4869,7 +4870,7 @@ ul.jqtree_common li.jqtree-folder {
 .ep-tools-login {
     border: none;
     padding-left: 16px;
-    padding-right: 20px;
+    padding-right: 16px;
     vertical-align: middle
 }
 

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -335,7 +335,7 @@
 
                                     <!-- Notifications -->
                                     {% if nav.notifs %}
-                                    <a href="#" class="ep-tools ep-notifs-toggle ep-tools-right" data-bind="click: function() {getNotifications();}" aria-label="{% trans "Alerts" %}">
+                                    <a href="#" class="ep-tools ep-notifs-toggle ep-tools-right" data-bind="click: function() { getNotifications(); givepanelfocus('class','ep-notifs-close'); }" aria-label="{% trans "Alerts" %}">
                                         <div class="top-btn-container" data-placement="bottom" data-toggle="tooltip" aria-expanded="true" data-original-title="{% trans 'Alerts' %}">
                                             <i class="fa fa-bell" aria-hidden="true" aria-label="{% trans "Alerts" %}"></i>
                                             <div data-bind="visible: unreadNotifs()" id="circle"></div>
@@ -393,7 +393,7 @@
                                     {% endif %}
 
                                     {% if nav.help %}
-                                    <a href="javascript:void(0)" class="ep-help-toggle ep-tools ep-tools-right" data-bind="click: function(){ getHelp('{{ nav.help.template }}'); helpOpen(true) }" aria-label="Help">
+                                    <a href="javascript:void(0)" class="ep-help-toggle ep-tools ep-tools-right" data-bind="click: function(){ getHelp('{{ nav.help.template }}'); helpOpen(true); givepanelfocus('class','ep-help-close'); }" aria-label="Help">
                                         <div class="top-btn-container" data-placement="bottom" data-toggle="tooltip" data-original-title='{% trans "Help" %}'>
                                             <i class="fa fa-question" aria-hidden="true" aria-label="{% trans "Help" %}"></i>
                                             <div class="top-btn-txt hidden-xs">
@@ -415,7 +415,7 @@
                                     <div class="ep-help-title">
                                         <span>{% trans 'Alerts / Notifications' %}</span>
                                     </div>
-                                    <a href="javascript:void(0);" data-bind="click: function() {getNotifications();}" class="ep-notifs-toggle ep-notifs-close ep-tools ep-tools-right" style="border:none;">
+                                    <a href="javascript:void(0);" data-bind="click: function() { getNotifications(); }" class="ep-notifs-toggle ep-notifs-close ep-tools ep-tools-right" style="border:none;" aria-label="Close the alerts/notifications popup" role="button">
                                         <div data-placement="bottom" data-toggle="tooltip" data-original-title='{% trans "Close" %}'>
                                         <i class="fa fa-times-circle fa-lg"></i>
                                         </div>
@@ -455,7 +455,7 @@
                                 <div class="ep-help-title">
                                     <span>{% trans nav.help.title %}</span>
                                 </div>
-                                <a href="javascript:void(0);" class="ep-help-toggle ep-help-close ep-tools ep-tools-right" style="border:none" data-bind="click: function(){helpOpen(false)}">
+                                <a href="javascript:void(0);" class="ep-help-toggle ep-help-close ep-tools ep-tools-right" style="border:none" data-bind="click: function(){helpOpen(false)}" aria-label="Close the help popup" role="button">
                                     <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title='{% trans "Close Help" %}'>
                                     <i class="fa fa-times-circle fa-lg"></i>
                                     </div>

--- a/arches/app/templates/base.htm
+++ b/arches/app/templates/base.htm
@@ -229,7 +229,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 }
             } else {
                 if(document.getElementsByClassName(elName)[0]) {
-                    document.getElementsByClassName(elName)[0].focus();
+                    setTimeout(function(){
+                        document.getElementsByClassName(elName)[0].focus();
+                    },0);
                 }
             }
             return;


### PR DESCRIPTION
Copied from task 24677...

Ensured that when opening the alerts or help popup, that the focus is given to the first available, tabbable element in that popup. Sometimes it seems to read out correctly, other times it doesn't.

I've done all I can with both these buttons/links. So if it doesn't pass testing I would suggest perhaps marking as a burden as I cant feasibly change the entire way all popups/panels open even if I would like to rip it all apart and make right using proper accessible bootstraps navs/modals etc.