### PR TITLE
Bug 24132: Made initial focus skip to content link

### DIFF
--- a/arches/app/templates/change_password.htm
+++ b/arches/app/templates/change_password.htm
@@ -32,7 +32,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             <div class="form-group">
                                 <label class="reqlabel control-label widget-input-label" for="old_password">Old Password (required)</label>
                                 <div class="input-group">
-                                    <input id="old_password" type="password" class="form-control input-lg" data-bind="textInput:credentials.old_password" name='old_password' autofocus aria-required="true">
+                                    <input id="old_password" type="password" class="form-control input-lg" data-bind="textInput:credentials.old_password" name='old_password' aria-required="true">
                                     <div class="error-message" data-bind="text:invalidPassword"></div>
                                 </div>
                             </div>

--- a/arches/app/templates/views/user-profile-manager.htm
+++ b/arches/app/templates/views/user-profile-manager.htm
@@ -61,7 +61,7 @@
                                         <div class="col-sm-7">
                                             <h4 class="text-main">{% trans 'Password' %}</h4>
                                             <p class="profile-label-shim">********</p>
-                                            <button class="btn btn-default btn-active-success btn-profile-password add-popover" data-bind='click: toggleChangePasswordForm' aria-label="Change password">
+                                            <button class="btn btn-default btn-active-success btn-profile-password add-popover" data-bind="click: function() { toggleChangePasswordForm(); document.getElementById('old_password').focus(); }" aria-label="Change password">
                                             {% trans 'Change password' %}</button>
                                             <div class="password-success" data-bind="text:changePasswordSuccess"></div>
                                             <div class="change-password-form bottom fade in popover" data-bind='visible: showChangePasswordForm()'>


### PR DESCRIPTION
There was an "autofocus" attribute set on the old password form field and this was causing the natural document tab ordering to not display the "skip to content" link as expected. Removed this attribute and therefor now works as on other pages.

Applying the above fix caused the old password field to not have focus after clicking on the "Change password" link, so made a slight javascript change to carry on that functionality.