### PR TITLE
Bug 23594: Fixed heading cutting off

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -4589,6 +4589,8 @@ ul.jqtree_common li.jqtree-folder {
 
 .profile-header {
     font-size: 21px;
+    text-align: left;
+    margin-top:5px;
 }
 
 .account-summary {
@@ -4689,9 +4691,7 @@ ul.jqtree_common li.jqtree-folder {
 }
 
 .project-search-widget {
-    position: absolute;
-    top: -45px;
-    width: 250px;
+    max-width: 250px;
 }
 
 .profile-default-message-panel {

--- a/arches/app/templates/views/user-profile-manager.htm
+++ b/arches/app/templates/views/user-profile-manager.htm
@@ -277,10 +277,7 @@
 
                 <!-- My Surveys -->
                 <div class="profile-list profile-projects">
-                    <h3 class="profile-header">
-                        {% trans 'My Collector Projects' %}
-                    </h3>
-
+                    
                     <!--ko ifnot: mobilesurveys.length -->
                     <div id="default-mobile-projects" class="profile-default-message-panel">
                         {% trans "Sorry, but you haven't been invited to a project yet..." %}
@@ -291,9 +288,13 @@
                     <!-- Survey Invitations List -->
                     <div id="mobile-projects-list" class="profile-default-message-panel">
                         <div class="row">
-
+                            <div class="col-xs-12 col-sm-3">
+                                <h3 class="profile-header">
+                                    {% trans 'My Collector Projects' %}
+                                </h3>
+                            </div>
                             <!-- Find a survey -->
-                            <div class="col-sm-9 col-sm-offset-3 relative">
+                            <div class="col-xs-12 col-sm-9">
                                 <div class="project-search-widget">
                                     <input type="text" class="form-control" placeholder="{% trans 'Find a project...' %}" aria-label="{% trans 'Find a project...' %}" data-bind="value: mobileSurveyFilter, valueUpdate: 'keyup'">
                                     <span class="clear-node-search" data-bind="visible: mobileSurveyFilter().length > 0, click: function() { mobileSurveyFilter(''); }"><i class="fa fa-times-circle"></i></span>


### PR DESCRIPTION
On the profile manager page, ensured that the "My Collector Projects" heading does not cut off when viewing with smaller screen widths/mobiles/tablets.