### PR TITLE
6673 allow app specific email config 5.1

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -166,6 +166,7 @@ class DLanguage(models.Model):
     def __str__(self):
         return f"{self.languageid} ({self.languagename})"
 
+
 class DNodeType(models.Model):
     nodetype = models.TextField(primary_key=True)
     namespace = models.TextField()
@@ -695,9 +696,21 @@ class ResourceXResource(models.Model):
     relationshiptype = models.TextField(blank=True, null=True)
     inverserelationshiptype = models.TextField(blank=True, null=True)
     tileid = models.ForeignKey(
-        "TileModel", db_column="tileid", blank=True, null=True, related_name="resxres_tile_id", on_delete=models.CASCADE,
+        "TileModel",
+        db_column="tileid",
+        blank=True,
+        null=True,
+        related_name="resxres_tile_id",
+        on_delete=models.CASCADE,
     )
-    nodeid = models.ForeignKey("Node", db_column="nodeid", blank=True, null=True, related_name="resxres_node_id", on_delete=models.CASCADE,)
+    nodeid = models.ForeignKey(
+        "Node",
+        db_column="nodeid",
+        blank=True,
+        null=True,
+        related_name="resxres_node_id",
+        on_delete=models.CASCADE,
+    )
     datestarted = models.DateField(blank=True, null=True)
     dateended = models.DateField(blank=True, null=True)
     created = models.DateTimeField()
@@ -1060,10 +1073,10 @@ class UserProfile(models.Model):
     phone = models.CharField(max_length=16, blank=True)
 
     def is_reviewer(self):
-        """ DEPRECATED Use new pattern:
+        """DEPRECATED Use new pattern:
 
-            from arches.app.utils.permission_backend import user_is_resource_reviewer
-            is_reviewer = user_is_resource_reviewer(user)
+        from arches.app.utils.permission_backend import user_is_resource_reviewer
+        is_reviewer = user_is_resource_reviewer(user)
         """
         pass
 
@@ -1196,8 +1209,7 @@ class UserXNotificationType(models.Model):
 
 @receiver(post_save, sender=UserXNotification)
 def send_email_on_save(sender, instance, **kwargs):
-    """Checks if a notification type needs to send an email, does so if email server exists
-    """
+    """Checks if a notification type needs to send an email, does so if email server exists"""
 
     if instance.notif.notiftype is not None and instance.isread is False:
         if UserXNotificationType.objects.filter(user=instance.recipient, notiftype=instance.notif.notiftype, emailnotify=False).exists():
@@ -1212,7 +1224,7 @@ def send_email_on_save(sender, instance, **kwargs):
                 email_to = instance.recipient.email
             else:
                 email_to = context["email"]
-            subject, from_email, to = instance.notif.notiftype.name, "from@example.com", email_to
+            subject, from_email, to = instance.notif.notiftype.name, settings.DEFAULT_FROM_EMAIL, email_to
             msg = EmailMultiAlternatives(subject, text_content, from_email, [to])
             msg.attach_alternative(html_content, "text/html")
             msg.send()

--- a/arches/app/views/user.py
+++ b/arches/app/views/user.py
@@ -107,7 +107,9 @@ class UserManagerView(BaseManagerView):
     def get(self, request):
 
         if self.request.user.is_authenticated and self.request.user.username != "anonymous":
-            context = self.get_context_data(main_script="views/user-profile-manager", )
+            context = self.get_context_data(
+                main_script="views/user-profile-manager",
+            )
 
             user_details = self.get_user_details(request.user)
 
@@ -139,7 +141,9 @@ class UserManagerView(BaseManagerView):
 
             user_details = self.get_user_details(request.user)
 
-            context = self.get_context_data(main_script="views/user-profile-manager", )
+            context = self.get_context_data(
+                main_script="views/user-profile-manager",
+            )
             context["errors"] = []
             context["nav"]["icon"] = "fa fa-user"
             context["nav"]["title"] = _("Profile Manager")
@@ -166,10 +170,13 @@ class UserManagerView(BaseManagerView):
                 try:
                     admin_info = settings.ADMINS[0][1] if settings.ADMINS else ""
                     message = _(
-                        "Your arches profile was just changed.  If this was unexpected, please contact your Arches administrator at %s."
-                        % (admin_info)
+                        "Your "
+                        + settings.APP_NAME
+                        + " profile was just changed.  If this was unexpected, please contact your "
+                        + settings.APP_NAME
+                        + " administrator at %s." % (admin_info)
                     )
-                    user.email_user(_("You're Arches Profile Has Changed"), message)
+                    user.email_user(_("Your " + settings.APP_NAME + " Profile Has Changed"), message)
                 except Exception as e:
                     print(e)
                 request.user = user

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -182,9 +182,12 @@ if DEBUG is True:
 # EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'  #<-- Only need to uncomment this for testing without an actual email server
 # EMAIL_USE_TLS = True
 # EMAIL_HOST = 'smtp.gmail.com'
-# EMAIL_HOST_USER = 'xxxx@xxx.com'
+EMAIL_HOST_USER = 'xxxx@xxx.com'
 # EMAIL_HOST_PASSWORD = 'xxxxxxx'
 # EMAIL_PORT = 587
+
+# Change if you need an alternate 'from' address for notifications that is different from your EMAIL_HOST_USER email address.
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 CELERY_BROKER_URL = "" # RabbitMQ --> "amqp://guest:guest@localhost",  Redis --> "redis://localhost:6379/0"
 CELERY_ACCEPT_CONTENT = ['json']
@@ -211,8 +214,8 @@ RESTRICT_MEDIA_ACCESS = False
 # to see how the language code is derived in the actual code
 
 ####### TO GENERATE .PO FILES DO THE FOLLOWING ########
-# run the following commands 
-# language codes used in the command should be in the form (which is slightly different 
+# run the following commands
+# language codes used in the command should be in the form (which is slightly different
 # form the form used in the LANGUAGE_CODE and LANGUAGES settings below):
 # --local={countrycode}_{REGIONCODE} <-- countrycode is lowercase, regioncode is uppercase, also notice the underscore instead of hyphen
 # commands to run (to generate files for "British English, German, and Spanish"):
@@ -226,7 +229,7 @@ RESTRICT_MEDIA_ACCESS = False
 # a list of language codes can be found here http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = "en"
 
-# list of languages to display in the language switcher, 
+# list of languages to display in the language switcher,
 # if left empty or with a single entry then the switch won't be displayed
 # language codes need to be all lower case with the form:
 # {langcode}-{regioncode} eg: en, en-gb ....

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -150,9 +150,12 @@ SESSION_COOKIE_NAME = "arches"
 # EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'  #<-- Only need to uncomment this for testing without an actual email server
 # EMAIL_USE_TLS = True
 # EMAIL_HOST = 'smtp.gmail.com'
-# EMAIL_HOST_USER = 'xxxx@xxx.com'
+EMAIL_HOST_USER = "xxxx@xxx.com"
 # EMAIL_HOST_PASSWORD = 'xxxxxxx'
 # EMAIL_PORT = 587
+
+# Change if you need an alternate 'from' address for notifications that is different from your EMAIL_HOST_USER email address.
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 POSTGIS_VERSION = (3, 0, 0)
 
@@ -375,7 +378,11 @@ except Exception as e:
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {"console": {"format": "%(asctime)s %(name)-12s %(levelname)-8s %(message)s",},},
+    "formatters": {
+        "console": {
+            "format": "%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+        },
+    },
     "handlers": {
         "file": {
             "level": "WARNING",  # DEBUG, INFO, WARNING, ERROR, CRITICAL


### PR DESCRIPTION
Code modifications to fix issues with download link - as detailed in bug [6673](https://github.com/archesproject/arches/issues/6673)

Brief summary:

- New setting DEFAULT_FROM_EMAIL added to settings.py and settings.py-tpl.  Set DEFAUL_FROM_EMAIL to reference EMAIL_HOST_USER which is now uncommented
- Used for setting e-mail address in models\models.py
- In user.py:
    - Typo Fix in Email Subject Line
    - Replaced hardcoded App Name (i.e. Arches) with settings.APP_NAME to make configurable.