### PR TITLE
Enabled concurrent refresh for mv_geojson

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -997,7 +997,7 @@ class GeojsonFeatureCollectionDataType(BaseDataType):
         elif settings.AUTO_REFRESH_GEOM_VIEW:
             cursor = connection.cursor()
             sql = """
-                REFRESH MATERIALIZED VIEW mv_geojson_geoms;
+                REFRESH MATERIALIZED VIEW CONCURRENTLY mv_geojson_geoms;
             """
             cursor.execute(sql)
 

--- a/arches/app/models/migrations/7012_mv_geojson_add_unique_index.py
+++ b/arches/app/models/migrations/7012_mv_geojson_add_unique_index.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("models", "5605_searchexporthistory_downloadfile")]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            DROP MATERIALIZED VIEW mv_geojson_geoms;
+            CREATE MATERIALIZED VIEW mv_geojson_geoms AS
+                SELECT public.uuid_generate_v1mc() AS uid,
+                    t.tileid,
+                    t.resourceinstanceid,
+                    n.nodeid,
+                    ST_Transform(ST_SetSRID(
+                    st_geomfromgeojson(
+                        (
+                            json_array_elements(
+                                t.tiledata::json ->
+                                n.nodeid::text ->
+                            'features') -> 'geometry'
+                        )::text
+                    ),
+                    4326
+                ), 3857) AS geom
+                FROM tiles t
+                LEFT JOIN nodes n ON t.nodegroupid = n.nodegroupid
+                WHERE n.datatype = 'geojson-feature-collection'::text;
+
+            CREATE UNIQUE INDEX ON mv_geojson_geoms (uid);
+            CREATE INDEX mv_geojson_geoms_gix ON mv_geojson_geoms USING GIST (geom);
+            """,
+        )
+    ]

--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -88,7 +88,7 @@ def export_search_results(self, userid, request_values, format):
 def refresh_materialized_view(self):
     cursor = connection.cursor()
     sql = """
-        REFRESH MATERIALIZED VIEW mv_geojson_geoms;
+        REFRESH MATERIALIZED VIEW CONCURRENTLY mv_geojson_geoms;
     """
     cursor.execute(sql)
     response = {"taskid": self.request.id}


### PR DESCRIPTION
Changed the **_mv_geojson_geom_** MV so that it has a unique id and unique index to allow CONCURRENT reresh of the data to be called.

Updated the code that calls the refresh to use the CONCURRENT option