### PR TITLE
7657 restrict bg export

### DIFF
--- a/arches/app/templates/views/components/search/search-export.htm
+++ b/arches/app/templates/views/components/search/search-export.htm
@@ -50,8 +50,6 @@
             <div data-bind="component: { name: 'views/components/simple-switch', params: {value: reportlink, config:{ label: '{% trans "Include the report link in the export?" %}', subtitle: ''}}}"></div>
         </div>
         <!-- ko if: total() > {{app_settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD}} && celeryRunning() === "True" && ("{{app_settings.RESTRICT_BG_EXPORT_ANON}}" === "False" || "{{app_settings.RESTRICT_BG_EXPORT_ANON}}" === "True" && "{{user.username}}" !== "anonymous")-->
-
-
         <div>
             <div class="instruction">
                 <h2>{% trans "4. Name this export" %}</h2>

--- a/arches/app/templates/views/components/search/search-export.htm
+++ b/arches/app/templates/views/components/search/search-export.htm
@@ -49,7 +49,9 @@
         <div class="parameter">
             <div data-bind="component: { name: 'views/components/simple-switch', params: {value: reportlink, config:{ label: '{% trans "Include the report link in the export?" %}', subtitle: ''}}}"></div>
         </div>
-        <!-- ko if: total() > {{app_settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD}} && celeryRunning() === "True" -->
+        <!-- ko if: total() > {{app_settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD}} && celeryRunning() === "True" && ("{{app_settings.RESTRICT_BG_EXPORT_ANON}}" === "False" || "{{app_settings.RESTRICT_BG_EXPORT_ANON}}" === "True" && "{{user.username}}" !== "anonymous")-->
+
+
         <div>
             <div class="instruction">
                 <h2>{% trans "4. Name this export" %}</h2>

--- a/arches/app/templates/views/components/search/search-export.htm
+++ b/arches/app/templates/views/components/search/search-export.htm
@@ -49,7 +49,7 @@
         <div class="parameter">
             <div data-bind="component: { name: 'views/components/simple-switch', params: {value: reportlink, config:{ label: '{% trans "Include the report link in the export?" %}', subtitle: ''}}}"></div>
         </div>
-        <!-- ko if: total() > {{app_settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD}} && celeryRunning() === "True" && ("{{app_settings.RESTRICT_BG_EXPORT_ANON}}" === "False" || "{{app_settings.RESTRICT_BG_EXPORT_ANON}}" === "True" && "{{user.username}}" !== "anonymous")-->
+        <!-- ko if: total() > {{app_settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD}} && celeryRunning() === "True" && ("{{app_settings.RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER}}" === "False" || "{{app_settings.RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER}}" === "True" && "{{user.username}}" !== "anonymous")-->
         <div>
             <div class="instruction">
                 <h2>{% trans "4. Name this export" %}</h2>

--- a/arches/app/utils/context_processors.py
+++ b/arches/app/utils/context_processors.py
@@ -74,6 +74,6 @@ def app_settings(request):
             "SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD": settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD,
             "RENDERERS": settings.RENDERERS,
             "FORCE_SCRIPT_NAME": settings.FORCE_SCRIPT_NAME if settings.FORCE_SCRIPT_NAME is not None else "",
-            "RESTRICT_BG_EXPORT_ANON": settings.RESTRICT_BG_EXPORT_ANON,
+            "RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER": settings.RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER,
         }
     }

--- a/arches/app/utils/context_processors.py
+++ b/arches/app/utils/context_processors.py
@@ -74,5 +74,6 @@ def app_settings(request):
             "SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD": settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD,
             "RENDERERS": settings.RENDERERS,
             "FORCE_SCRIPT_NAME": settings.FORCE_SCRIPT_NAME if settings.FORCE_SCRIPT_NAME is not None else "",
+            "RESTRICT_BG_EXPORT_ANON": settings.RESTRICT_BG_EXPORT_ANON,
         }
     }

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -211,7 +211,7 @@ def export_results(request):
     download_limit = settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
     app_name = settings.APP_NAME
     if total > download_limit and format != "geojson":
-        if (settings.RESTRICT_BG_EXPORT_ANON == True) and (request.user.username == "anonymous"):
+        if (settings.RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER == True) and (request.user.username == "anonymous"):
             message = _(
                 "Your search exceeds the {download_limit} instance download limit.  Anonymous users cannot run an export exceeding this limit. Please sign in with your {app_name} account or refine your search"
             ).format(**locals())

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -52,6 +52,7 @@ from arches.app.models.system_settings import settings
 
 logger = logging.getLogger(__name__)
 
+
 class SearchView(MapBaseManagerView):
     def get(self, request):
         map_layers = models.MapLayer.objects.all()
@@ -112,7 +113,13 @@ class SearchView(MapBaseManagerView):
 
 
 def home_page(request):
-    return render(request, "views/search.htm", {"main_script": "views/search",})
+    return render(
+        request,
+        "views/search.htm",
+        {
+            "main_script": "views/search",
+        },
+    )
 
 
 def search_terms(request):
@@ -205,8 +212,10 @@ def export_results(request):
     download_limit = settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
     app_name = settings.APP_NAME
     if total > download_limit and format != "geojson":
-        if (settings.RESTRICT_BG_EXPORT_ANON == True) and (request.user.username == 'anonymous'):
-            message = _("Your search exceeds the {download_limit} instance download limit.  Anonymous users cannot run an export exceeding this limit. Please sign in with your {app_name} account or refine your search").format(**locals())
+        if (settings.RESTRICT_BG_EXPORT_ANON == True) and (request.user.username == "anonymous"):
+            message = _(
+                "Your search exceeds the {download_limit} instance download limit.  Anonymous users cannot run an export exceeding this limit. Please sign in with your {app_name} account or refine your search"
+            ).format(**locals())
             return JSONResponse({"success": False, "message": message})
         else:
             celery_worker_running = task_management.check_if_celery_available()
@@ -214,7 +223,9 @@ def export_results(request):
                 request_values = dict(request.GET)
                 request_values["path"] = request.get_full_path()
                 result = tasks.export_search_results.apply_async(
-                    (request.user.id, request_values, format, report_link), link=tasks.update_user_task_record.s(), link_error=tasks.log_error.s()
+                    (request.user.id, request_values, format, report_link),
+                    link=tasks.update_user_task_record.s(),
+                    link_error=tasks.log_error.s(),
                 )
                 message = _(
                     "{total} instances have been submitted for export. \
@@ -222,7 +233,9 @@ def export_results(request):
                 ).format(**locals())
                 return JSONResponse({"success": True, "message": message})
             else:
-                message = _("Your search exceeds the {download_limit} instance download limit. Please refine your search").format(**locals())
+                message = _("Your search exceeds the {download_limit} instance download limit. Please refine your search").format(
+                    **locals()
+                )
                 return JSONResponse({"success": False, "message": message})
 
     elif format == "tilexl":
@@ -237,7 +250,7 @@ def export_results(request):
             return zip_utils.zip_response(export_files, zip_file_name=f"{settings.APP_NAME}_export.zip")
     else:
         exporter = SearchResultsExporter(search_request=request)
-        export_files, export_info = exporter.export(format,report_link)
+        export_files, export_info = exporter.export(format, report_link)
 
         if len(export_files) == 0 and format == "shp":
             message = _(

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -48,6 +48,7 @@ import arches.app.tasks as tasks
 from io import StringIO
 from tempfile import NamedTemporaryFile
 from openpyxl import Workbook
+from arches.app.models.system_settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -202,22 +203,28 @@ def export_results(request):
     format = request.GET.get("format", "tilecsv")
     report_link = request.GET.get("reportlink", False)
     download_limit = settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
+    app_name = settings.APP_NAME
     if total > download_limit and format != "geojson":
-        celery_worker_running = task_management.check_if_celery_available()
-        if celery_worker_running is True:
-            request_values = dict(request.GET)
-            request_values["path"] = request.get_full_path()
-            result = tasks.export_search_results.apply_async(
-                (request.user.id, request_values, format, report_link), link=tasks.update_user_task_record.s(), link_error=tasks.log_error.s()
-            )
-            message = _(
-                "{total} instances have been submitted for export. \
-                Click the Bell icon to check for a link to download your data"
-            ).format(**locals())
-            return JSONResponse({"success": True, "message": message})
-        else:
-            message = _("Your search exceeds the {download_limit} instance download limit. Please refine your search").format(**locals())
+        if (settings.RESTRICT_BG_EXPORT_ANON == True) and (request.user.username == 'anonymous'):
+            message = _("Your search exceeds the {download_limit} instance download limit.  Anonymous users cannot run an export exceeding this limit. Please sign in with your {app_name} account or refine your search").format(**locals())
             return JSONResponse({"success": False, "message": message})
+        else:
+            celery_worker_running = task_management.check_if_celery_available()
+            if celery_worker_running is True:
+                request_values = dict(request.GET)
+                request_values["path"] = request.get_full_path()
+                result = tasks.export_search_results.apply_async(
+                    (request.user.id, request_values, format, report_link), link=tasks.update_user_task_record.s(), link_error=tasks.log_error.s()
+                )
+                message = _(
+                    "{total} instances have been submitted for export. \
+                    Click the Bell icon to check for a link to download your data"
+                ).format(**locals())
+                return JSONResponse({"success": True, "message": message})
+            else:
+                message = _("Your search exceeds the {download_limit} instance download limit. Please refine your search").format(**locals())
+                return JSONResponse({"success": False, "message": message})
+
     elif format == "tilexl":
         exporter = SearchResultsExporter(search_request=request)
         export_files, export_info = exporter.export(format, report_link)

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -52,7 +52,6 @@ from arches.app.models.system_settings import settings
 
 logger = logging.getLogger(__name__)
 
-
 class SearchView(MapBaseManagerView):
     def get(self, request):
         map_layers = models.MapLayer.objects.all()

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -232,10 +232,10 @@ CANTALOUPE_HTTP_ENDPOINT = "http://localhost:8182/"
 # By setting RESTRICT_MEDIA_ACCESS to True, media file requests outside of Arches will checked against nodegroup permissions.
 RESTRICT_MEDIA_ACCESS = False
 
-# By setting RESTRICT_BG_EXPORT_ANON to True, if the user is attempting
+# By setting RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER to True, if the user is attempting
 # to export search results above the SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
 # value and is not signed in with a user account then the request will not be allowed.
-RESTRICT_BG_EXPORT_ANON = False
+RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER = False
 
 # see https://docs.djangoproject.com/en/1.9/topics/i18n/translation/#how-django-discovers-language-preference
 # to see how LocaleMiddleware tries to determine the user's language preference

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -229,7 +229,6 @@ CELERY_BEAT_SCHEDULE = {
 CANTALOUPE_DIR = os.path.join(ROOT_DIR, "uploadedfiles")
 CANTALOUPE_HTTP_ENDPOINT = "http://localhost:8182/"
 
-
 # By setting RESTRICT_MEDIA_ACCESS to True, media file requests outside of Arches will checked against nodegroup permissions.
 RESTRICT_MEDIA_ACCESS = False
 
@@ -237,7 +236,6 @@ RESTRICT_MEDIA_ACCESS = False
 # to export search results above the SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
 # value and is not signed in with a user account then the request will not be allowed.
 RESTRICT_BG_EXPORT_ANON = False
-
 
 # see https://docs.djangoproject.com/en/1.9/topics/i18n/translation/#how-django-discovers-language-preference
 # to see how LocaleMiddleware tries to determine the user's language preference

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -229,8 +229,14 @@ CELERY_BEAT_SCHEDULE = {
 CANTALOUPE_DIR = os.path.join(ROOT_DIR, "uploadedfiles")
 CANTALOUPE_HTTP_ENDPOINT = "http://localhost:8182/"
 
+
 # By setting RESTRICT_MEDIA_ACCESS to True, media file requests outside of Arches will checked against nodegroup permissions.
 RESTRICT_MEDIA_ACCESS = False
+
+# By setting RESTRICT_BG_EXPORT_ANON to True, if the user is attempting
+# to export search results above the SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
+# value and is not signed in with a user account then the request will not be allowed.
+RESTRICT_BG_EXPORT_ANON = False
 
 
 # see https://docs.djangoproject.com/en/1.9/topics/i18n/translation/#how-django-discovers-language-preference

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -229,10 +229,10 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 15728640
 RESTRICT_MEDIA_ACCESS = False
 
 
-# By setting RESTRICT_BG_EXPORT_ANON to True, if the user is attempting
+# By setting RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER to True, if the user is attempting
 # to export search results above the SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
 # value and is not signed in with a user account then the request will not be allowed.
-RESTRICT_BG_EXPORT_ANON = False
+RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER = False
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 MEDIA_ROOT = os.path.join(ROOT_DIR)

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -228,6 +228,12 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 15728640
 # However, this will adversely impact performace when serving large files or during periods of high traffic.
 RESTRICT_MEDIA_ACCESS = False
 
+
+# By setting RESTRICT_BG_EXPORT_ANON to True, if the user is attempting
+# to export search results above the SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
+# value and is not signed in with a user account then the request will not be allowed.
+RESTRICT_BG_EXPORT_ANON = False
+
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 MEDIA_ROOT = os.path.join(ROOT_DIR)
 


### PR DESCRIPTION
Tested on local install.

- Adds parameter in settings and context_processor to switch on or off exporting over the threshold limit for anonymous users.
- Provides logic for returning a message when RESTRICT_BG_EXPORT_ANON is true and limit is exceeded by an anonymous user
- Hides the email and search export name inputs from search export template when RESTRICT_BG_EXPORT_ANON is true and limit is exceeded by an anonymous user