### PR TITLE
Allow ordering of exported nodes

### DIFF
--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -153,7 +153,7 @@ class SearchResultsExporter(object):
                     header_object["fieldname"] = node_object.fieldname
                     header_object["datatype"] = node_object.datatype
                     header_object["name"] = node_object.name
-                    if node_object.id not in node_id_list:
+                    if node_object.nodeid not in node_id_list:
                         headers.append(header_object)
                         node_id_list.append(node_object.nodeid)
                     else:
@@ -198,7 +198,12 @@ class SearchResultsExporter(object):
                     resource["Link"] = f"{export_namespace}{report_url}"
 
             if format == "geojson":
-                headers = list(graph.node_set.filter(exportable=True).values_list("name", flat=True))
+
+                if settings.EXPORT_DATA_FIELDS_IN_CARD_ORDER == True:
+                    headers = self.return_ordered_header(graph_id, "csv")
+                else:
+                    headers = list(graph.node_set.filter(exportable=True).values_list("name", flat=True))
+
                 if (report_link == "true") and ("Link" not in headers):
                     headers.append("Link")
                 ret = self.to_geojson(resources["output"], headers=headers, name=graph.name)
@@ -229,7 +234,7 @@ class SearchResultsExporter(object):
                 for header in headers:
                     if not header["fieldname"]:
                         missing_field_names.append(header["name"])
-                    header.pop("name")
+                        header.pop("name")
                 if len(missing_field_names) > 0:
                     message = _("Shapefile are fieldnames required for the following nodes: {0}".format(", ".join(missing_field_names)))
                     logger.error(message)

--- a/arches/app/utils/response.py
+++ b/arches/app/utils/response.py
@@ -3,6 +3,7 @@ import logging
 from django.http import HttpResponse
 from django.utils.translation import ugettext as _
 from arches.app.utils.betterJSONSerializer import JSONSerializer
+from arches.app.models.system_settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +15,7 @@ class JSONResponse(HttpResponse):
         stream = kwargs.pop("stream", None)
         indent = kwargs.pop("indent", None)
         selected_fields = kwargs.pop("fields", None)
+        sort_keys = kwargs.pop("sort_keys", None)
         use_natural_keys = kwargs.pop("use_natural_keys", None)
         geom_format = kwargs.pop("geom_format", None)
 
@@ -32,6 +34,8 @@ class JSONResponse(HttpResponse):
             options["indent"] = indent
         if selected_fields is not None:
             options["selected_fields"] = selected_fields
+        if sort_keys is not None:
+            options["sort_keys"] = sort_keys
         if use_natural_keys is not None:
             options["use_natural_keys"] = use_natural_keys
         if geom_format is not None:

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -583,13 +583,7 @@ class Resources(APIBase):
                 hide_empty_nodes = bool(request.GET.get("hide_empty_nodes", "false").lower() == "true")  # default False
 
                 out = {
-                    "resource": resource.to_json(
-                        compact=compact,
-                        hide_empty_nodes=hide_empty_nodes,
-                        user=user,
-                        perm=perm,
-                        version=version
-                    ),
+                    "resource": resource.to_json(compact=compact, hide_empty_nodes=hide_empty_nodes, user=user, perm=perm, version=version),
                     "displaydescription": resource.displaydescription,
                     "displayname": resource.displayname,
                     "graph_id": resource.graph_id,
@@ -976,7 +970,10 @@ class SearchExport(View):
         exporter = SearchResultsExporter(search_request=request)
         export_files, export_info = exporter.export(format, report_link)
         if format == "geojson" and total <= download_limit:
-            response = JSONResponse(export_files)
+            if settings.EXPORT_DATA_FIELDS_IN_CARD_ORDER == True:
+                response = JSONResponse(export_files, sort_keys=False)
+            else:
+                response = JSONResponse(export_files)
             return response
         return JSONResponse(status=404)
 

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -174,6 +174,10 @@ BYPASS_REQUIRED_VALUE_TILE_VALIDATION = False
 
 DATE_IMPORT_EXPORT_FORMAT = "%Y-%m-%d" # Custom date format for dates imported from and exported to csv
 
+# This is used to indicate whether the data in the CSV and SHP exports should be
+# ordered as seen in the resource cards or not.
+EXPORT_DATA_FIELDS_IN_CARD_ORDER = False
+
 #Identify the usernames and duration (seconds) for which you want to cache the time wheel
 CACHE_BY_USER = {'anonymous': 3600 * 24}
 TILE_CACHE_TIMEOUT = 600 #seconds

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -131,7 +131,7 @@ ARCHES_NAMESPACE_FOR_DATA_EXPORT = "http://localhost:8000/"
 
 # This is used to indicate whether the data in the CSV and SHP exports should be
 # ordered as seen in the resource cards or not.
-EXPORT_DATA_FIELDS_IN_CARD_ORDER = True
+EXPORT_DATA_FIELDS_IN_CARD_ORDER = False
 
 RDM_JSONLD_CONTEXT = {"arches": ARCHES_NAMESPACE_FOR_DATA_EXPORT}
 

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -129,6 +129,10 @@ JSONLD_CONTEXT_CACHE_TIMEOUT = 43800  # in minutes (43800 minutes ~= 1 month)
 # Make sure to use a trailing slash
 ARCHES_NAMESPACE_FOR_DATA_EXPORT = "http://localhost:8000/"
 
+# This is used to indicate whether the data in the CSV and SHP exports should be
+# ordered as seen in the resource cards or not.
+EXPORT_DATA_FIELDS_IN_CARD_ORDER = True
+
 RDM_JSONLD_CONTEXT = {"arches": ARCHES_NAMESPACE_FOR_DATA_EXPORT}
 
 PREFERRED_COORDINATE_SYSTEMS = (


### PR DESCRIPTION
This functionality change allows administrators to enable a setting in the settings.py file to export values in CSV, SHP and GeoJSON format in the order they are set within a resource model's cards configuration.

