### PR TITLE
32782 resource select widget icons

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -11761,6 +11761,12 @@ a.search-facet-item.disabled {
     border-left: solid 1px #ccc;
 }
 
+.sml-icon-wrap {
+    display: inline-block;
+    padding: 5px;
+    border-radius: 2px;
+}
+
 .msm-icon-wrap {
     height: 60px;
     width: 60px;

--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -445,7 +445,7 @@ define([
             formatResult: function(item) {
                 if (item._source) {
                     iconclass = self.graphLookup[item._source.graph_id].iconclass
-                    return '<i class="fa ' + iconclass + '"></i> '+ item._source.displayname;
+                    return `<i class="fa ${iconclass} icon-wrap"></i> ${item._source.displayname}`;
                 } else {
                     if (self.allowInstanceCreation) {
                         return '<b> ' + arches.translations.riSelectCreateNew.replace('${graphName}', item.name) + ' . . . </b>';
@@ -455,7 +455,7 @@ define([
             formatSelection: function(item) {
                 if (item._source) {
                     iconclass = self.graphLookup[item._source.graph_id].iconclass
-                    return '<i class="fa ' + iconclass + '"></i> '+ item._source.displayname;
+                    return `<i class="fa ${iconclass} icon-wrap"></i> ${item._source.displayname}`;
                 } else {
                     return item.name;
                 }

--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -444,7 +444,8 @@ define([
             },
             formatResult: function(item) {
                 if (item._source) {
-                    return item._source.displayname;
+                    iconclass = self.graphLookup[item._source.graph_id].iconclass
+                    return '<i class="fa ' + iconclass + '"></i> '+ item._source.displayname;
                 } else {
                     if (self.allowInstanceCreation) {
                         return '<b> ' + arches.translations.riSelectCreateNew.replace('${graphName}', item.name) + ' . . . </b>';
@@ -453,7 +454,8 @@ define([
             },
             formatSelection: function(item) {
                 if (item._source) {
-                    return item._source.displayname;
+                    iconclass = self.graphLookup[item._source.graph_id].iconclass
+                    return '<i class="fa ' + iconclass + '"></i> '+ item._source.displayname;
                 } else {
                     return item.name;
                 }

--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -233,7 +233,7 @@ define([
                                     names.push(resourceInstance["_source"].displayname);
                                     self.displayValue(names.join(', '));
                                     val.resourceName(resourceInstance["_source"].displayname)
-                                    val.iconClass(self.graphLookup[resourceInstance["_source"].graph_id].iconclass)
+                                    val.iconClass(self.graphLookup[resourceInstance["_source"].graph_id]?.iconclass || 'fa fa-question')
                                     val.ontologyClass(resourceInstance["_source"].root_ontology_class);
                                 });
                         }
@@ -257,6 +257,7 @@ define([
 
         var makeObject = function(id, esSource){
             var graph = self.graphLookup[esSource.graph_id];
+            var iconClass = self.graphLookup[esSource.graph_id]?.iconclass  || 'fa fa-question';
 
             var ontologyProperty;
             var inverseOntologyProperty;
@@ -285,6 +286,7 @@ define([
             };            
             Object.defineProperty(ret, 'resourceName', {value: ko.observable(esSource.displayname)});
             Object.defineProperty(ret, 'ontologyClass', {value: ko.observable(esSource.root_ontology_class)});
+            Object.defineProperty(ret, 'iconClass', {value: ko.observable(iconClass)});
             if (!!params.configForm) {
                 ret.ontologyProperty.subscribe(function(){
                     self.defaultResourceInstance(self.value());
@@ -448,7 +450,7 @@ define([
             },
             formatResult: function(item) {
                 if (item._source) {
-                    iconclass = self.graphLookup[item._source.graph_id].iconclass
+                    iconclass = self.graphLookup[item._source.graph_id]?.iconclass  || 'fa fa-question'
                     return `<i class="fa ${iconclass} icon-wrap"></i> ${item._source.displayname}`;
                 } else {
                     if (self.allowInstanceCreation) {
@@ -458,7 +460,7 @@ define([
             },
             formatSelection: function(item) {
                 if (item._source) {
-                    iconclass = self.graphLookup[item._source.graph_id].iconclass
+                    iconclass = self.graphLookup[item._source.graph_id]?.iconclass || 'fa fa-question'
                     return `<i class="fa ${iconclass} icon-wrap"></i> ${item._source.displayname}`;
                 } else {
                     return item.name;

--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -225,11 +225,15 @@ define([
                             if(!val.ontologyClass) {
                                 Object.defineProperty(val, 'ontologyClass', {value:ko.observable()});
                             }
+                            if(!val.iconClass) {
+                                Object.defineProperty(val, 'iconClass', {value: ko.observable()});
+                            }
                             lookupResourceInstanceData(ko.unwrap(val.resourceId))
                                 .then(function(resourceInstance) {
                                     names.push(resourceInstance["_source"].displayname);
                                     self.displayValue(names.join(', '));
-                                    val.resourceName(resourceInstance["_source"].displayname);
+                                    val.resourceName(resourceInstance["_source"].displayname)
+                                    val.iconClass(self.graphLookup[resourceInstance["_source"].graph_id].iconclass)
                                     val.ontologyClass(resourceInstance["_source"].root_ontology_class);
                                 });
                         }

--- a/arches/app/templates/views/components/widgets/resource-instance-select.htm
+++ b/arches/app/templates/views/components/widgets/resource-instance-select.htm
@@ -68,7 +68,8 @@
                             </button>
                         </div>
                         <div class="rr-table-column" style="flex-grow: 1; cursor: pointer;" data-bind="click: function() { self.toggleSelectedResourceRelationship($data); }, clickBubble: false">
-                            <div class="rr-table-instance-label" style="padding-left: 10px;" data-bind="text: $data.resourceName()">
+                            <div class="rr-table-instance-label" style="padding-left: 10px;">
+                                <i class="sml-icon-wrap" data-bind="css: $data.iconClass()"></i><span data-bind="text: $data.resourceName()"></span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Adds the graph icon to resource labels in resource-instance select widget to identify what type each resource is. This is important where multiple resource types can be selected and have similar names. 

HE Ticket [AB#32782](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/32782)