### PR TITLE
32782 resource select widget icons AB#32782

### DIFF
--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -85,6 +85,7 @@ define([
                     .then(function(json){
                         self.graphLookup[graphid] = json.graph;
                         self.graphLookupKeys(Object.keys(self.graphLookup));
+                        self.value.valueHasMutated();
                         return json.graph;
                     });
             }


### PR DESCRIPTION
Ensures that resource instance list table in card widget gets updated with icon if graph once graph is downloaded. If it is slow then the icon remains as the ? question mark placeholder.