### PR TITLE
686 - Added target blank to link AB#33944

### DIFF
--- a/arches/app/templates/views/components/widgets/file.htm
+++ b/arches/app/templates/views/components/widgets/file.htm
@@ -166,7 +166,7 @@
 
 <!-- ko foreach: reportFiles() -->
 <dd>
-    <a class="" data-bind="attr: {href: $parent.getFileUrl(url)}">
+    <a data-bind="attr: {href: $parent.getFileUrl(url)}" target="_blank">
         <i class="ion ion-forward"></i>
         <span data-bind="text: name"></span>
     </a>


### PR DESCRIPTION
To enable a user to download a file within a report, in a new browser window/tab and continue viewing the report. Previously it was stuck on the spinning progress indicator.