### PR TITLE
Reinstate resource-report-abstract view

### DIFF
--- a/arches/app/templates/views/resource/editor.htm
+++ b/arches/app/templates/views/resource/editor.htm
@@ -143,10 +143,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <!--ko if: selection() === 'root' -->
                 <!--ko if: resourceId() -->
                 <div class='resource-report editor-report' data-bind='component: {
-                    name: reportLookup[report.get("template_id")()].componentname,
+                    name: "resource-report-abstract",
                     params: {
                         report: report,
-                        editorContext: true
+                        editorContext: true,
+                        cache: false
                     }
                 }'></div>
                 <!--/ko -->


### PR DESCRIPTION
When editing a resource (/resource) a major part of the hierarchy of getting the data from parent to child vires (partials/scenes) relies on an abstract view called resource-report-abstract.htm. editor.htm is responsible for bringing in this htm file which was broken resulting in all of the tabs showing no information.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
