### PR TITLE
Height fix for card wrapper AB#44717

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -13091,7 +13091,7 @@ ul.select2-choices:after {
 }
 
 .card-component-wrapper-editor {
-    height: 100%;
+    height: calc(100vh - 100px);
     padding-bottom: 50px;
     overflow-y: auto;
     background: #fafafa;


### PR DESCRIPTION
Fixed the issue by going by the view height instead of percentage, but catering for the 2 divs above in the layout which total 100px. When a long form in a card is tabbed to, the height remains and behaves as expected, without shifting any content up and hiding the top menu bars.