### PR TITLE
mapbox-gl control changes AB#46072 AB#46065

### DIFF
--- a/arches/app/media/js/bindings/mapbox-gl.js
+++ b/arches/app/media/js/bindings/mapbox-gl.js
@@ -40,6 +40,12 @@ define([
                     map.addImage(marker.name, image);
                 });
             });
+            //-- #46072: add scale control to map
+            map.addControl(new mapboxgl.ScaleControl({
+                maxWidth: 80,
+                unit: 'metric'
+            }));
+            //----------------
         });
 
         // prevents drag events from bubbling

--- a/arches/app/media/js/bindings/mapbox-gl.js
+++ b/arches/app/media/js/bindings/mapbox-gl.js
@@ -42,7 +42,7 @@ define([
             });
             //-- #46072: add scale control to map
             map.addControl(new mapboxgl.ScaleControl({
-                maxWidth: 80,
+                maxWidth: 200,
                 unit: 'metric'
             }));
             //----------------

--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -466,6 +466,7 @@ define([
                         accessToken: MapboxGl.accessToken,
                         mapboxgl: MapboxGl,
                         placeholder: arches.geocoderPlaceHolder,
+                        countries: "GB", // #46065 - force GB as a minimum
                         bbox: arches.hexBinBounds
                     }), 'top-right');
 


### PR DESCRIPTION
Keystone specific - not for core

- [AB#46072](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/46072) - adds a scale control
- [AB#46065](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/46065) - forces GB filter as a minimum for geocoder where bbox is not working