### PR TITLE
Enable restoreState to set the bounds on pageload AB#45869

### DIFF
--- a/arches/app/media/js/views/components/search/map-filter.js
+++ b/arches/app/media/js/views/components/search/map-filter.js
@@ -605,7 +605,7 @@ define([
                     this.mapFitBounds(bounds, {
                         padding: 45,
                         maxZoom: maxZoom
-                    });
+                    }, !this.pageLoaded);
                 }
             }
         }),


### PR DESCRIPTION
fixes issue where initial map-filter bounds at page load are not set which can cause the map to be fully zoomed out [AB#45869](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/45869)