### PR TITLE
Placeholder change to "Value" for String & EDTF

### DIFF
--- a/arches/app/templates/views/components/datatypes/edtf.htm
+++ b/arches/app/templates/views/components/datatypes/edtf.htm
@@ -13,7 +13,7 @@
     </select>
 </div>
 <div class="col-md-8 col-lg-9" data-bind="visible: op() !== 'null' && op() !== 'not_null'">
-    <input type="text" placeholder='{% trans "Name" %}' aria-label='{% trans "Name" %}' class="form-control input-lg" style="height: 36px;" data-bind="textInput: searchValue">
+    <input type="text" placeholder='{% trans "Value" %}' aria-label='{% trans "Value" %}' class="form-control input-lg" style="height: 36px;" data-bind="textInput: searchValue">
 </div>
 <!-- /ko -->
 

--- a/arches/app/templates/views/components/datatypes/string.htm
+++ b/arches/app/templates/views/components/datatypes/string.htm
@@ -12,6 +12,6 @@
 </div>
 
 <div class="col-md-8 col-lg-9" data-bind="visible: op() !== 'null' && op() !== 'not_null'">
-    <input type="text" placeholder='{% trans "Name" %}' aria-label='{% trans "Name" %}' class="form-control input-lg" style="height: 36px;" data-bind="value: searchValue, valueUpdate: 'keyup'">
+    <input type="text" placeholder='{% trans "Value" %}' aria-label='{% trans "Value" %}' class="form-control input-lg" style="height: 36px;" data-bind="value: searchValue, valueUpdate: 'keyup'">
 </div>
 <!-- /ko -->


### PR DESCRIPTION
Changing the hard-coded placeholder value in Advanced Search from Name to Value for EDTF and String datatypes to reduce confusion