### PR TITLE
8645 - Index domain datatypes refactoring.

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1611,12 +1611,8 @@ class DomainDataType(BaseDomainDataType):
         return terms
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
-        domain_text = None
-        for tile in document["tiles"]:
-            for k, v in tile.data.items():
-                if v == nodevalue:
-                    node = models.Node.objects.get(nodeid=k)
-                    domain_text = self.get_option_text(node, v)
+        node = models.Node.objects.get(nodeid=nodeid)
+        domain_text = self.get_option_text(node, nodevalue)
 
         if domain_text not in document["strings"] and domain_text is not None:
             document["strings"].append({"string": domain_text, "nodegroup_id": tile.nodegroup_id, "provisional": provisional})
@@ -1709,13 +1705,10 @@ class DomainListDataType(BaseDomainDataType):
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
         domain_text_values = set([])
-        for tile in document["tiles"]:
-            for k, v in tile.data.items():
-                if v == nodevalue:
-                    node = models.Node.objects.get(nodeid=k)
-                    for value in nodevalue:
-                        text_value = self.get_option_text(node, value)
-                        domain_text_values.add(text_value)
+        node = models.Node.objects.get(nodeid=nodeid)
+        for value in nodevalue:
+            text_value = self.get_option_text(node, value)
+            domain_text_values.add(text_value)
 
         for value in domain_text_values:
             if value not in document["strings"]:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
There seems to be iterations in the datatypes.py append_to_document process for DomainDatatype and DomainListDatatype that are no longer required.

Work is undertaken to deduce the Nodeid/NodeValue, however there has been subsequent refactoring of the code, and these are now supplied as arguments to the procedures.

If this unnecessary work is refactored out then the reindexing completes in a more expected timeframe.


### Issues Solved
[AB#43832](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/43832) - York Minster record takes excessively long to reindex.
#
