### PR TITLE
Accessibility give back - Workflows Menu Scrolling at 400% - AB#45532

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -4973,6 +4973,7 @@ ul .collapse li:last-of-type {
     width: 100%;
     height: calc(100vh - 50px);
     position: relative;
+    overflow-y:auto;
 }
 
 .flexrow {


### PR DESCRIPTION
Accessibility item giveback.  When the Workflows menu is zoomed in at 400% a vertical scrollbar allows the user to scroll down and view all options

- Add overflow-y to content-panel styling
[AB#45532](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/45532)