### PR TITLE
Add Arial label, Assertive and Role to alert panel AB#45228

### DIFF
--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -236,8 +236,12 @@
                     <!-- ko if: alert() -->
                     <div data-bind="visible: alert().active" style="display: none;" class="relative">
                         <div id="card-alert-panel" data-bind="css: 'ep-form-alert ' + (alert() ? alert().type() : '')">
-                            <h4 class="ep-form-alert-title" data-bind="text: alert().title"></h4>
-                            <p class="ep-form-alert-text" data-bind="html: alert().text"></p>
+                            <div data-bind="attr: {'aria-label': alert().title}" aria-live = "assertive" role="alert">
+                                <h4 class="ep-form-alert-title" data-bind="text: alert().title"></h4>
+                            </div>
+                            <div data-bind="attr: {'aria-label': alert().text}" aria-live = "assertive" role="alert">
+                                <p class="ep-form-alert-text" data-bind="html: alert().text"></p>
+                            </div>
 
                             <div class="ep-form-alert-default-dismiss">
                                 <i class="fa fa-times-circle" data-bind="click: alert().close"></i>

--- a/arches/app/templates/login.htm
+++ b/arches/app/templates/login.htm
@@ -49,10 +49,10 @@
 								</div>
 							</div>
 							<div class="row" style="padding-top:10px; margin: -20px 0px 5px 0px;">
-								<div style="{% if not auth_failed %}display:none;{% endif %}" id="login-failed-alert" class="alert alert-danger fade in" role="alert">
+								<div style="{% if not auth_failed %}display:none;{% endif %}" id="login-failed-alert" class="alert alert-danger fade in" aria-labelledby="login-fail-header login-fail-message"  aria-live="assertive"  role="alert">
 									<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans "Close" %}</span></button>
-									<h2>{% trans "Login failed" %}</h2>
-									<span>{% trans "Invalid username and/or password." %}</span>
+									<h2 role="alert" id="login-fail-header">{% trans "Login failed" %}</h2>
+									<span role="alert" id="login-fail-message">{% trans "Invalid username and/or password." %}</span>
 								</div>
 							</div>
 						</fieldset>

--- a/arches/app/templates/views/rdm/modals/import-concept-form.htm
+++ b/arches/app/templates/views/rdm/modals/import-concept-form.htm
@@ -36,8 +36,8 @@
                             </div>
                             <div class="row hidden">
                                 <div class="col-md-12">
-                                    <div class="alert alert-warning">
-                                        <h4>{% trans "Error" %}</h4>
+                                    <div class="alert alert-warning" aria-labelledby="error-text-header error_text"  aria-live="assertive"  role="alert">
+                                        <h4 role="alert" id="error-text-header">{% trans "Error" %}</h4>
                                         <p id='error_text' style="max-height:300px; overflow-y:scroll;"></p>
                                     </div>
                                 </div>


### PR DESCRIPTION
Re : 45228 - All Pages - 3.3.1 Error Identification - Errors are not programmatically determined

**Steps to Reproduce:**

1. Navigate to the any page in Keystone where it is possible to make an error (e.g. Login)
2. Activate NVDA screen reader
3. Enter non-valid details or leave fields blank
4. Click 'Sign In/Save'
5. View errors

**Expected Result:**

Screen reader should read out the error messages as soon as the user attempts to sign in and is redirected back to the sign-in page. Spoken text should exactly match the error message.

**Actual Result:**
The error message is not read out by the screen reader. 

**Note:**

The main alerts

- Login.
- Alert drop down