### PR TITLE
KH-R110 - Search exports not generating (Subcards may have subcards) AB#49409

### DIFF
--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -61,10 +61,9 @@ class SearchResultsExporter(object):
         self.set_precision = GeoUtils().set_precision
 
     def insert_subcard_below_parent_card(self, main_card_list, sub_card_list):
-        for sub_card in sub_card_list:
-            parent_obj = sub_card.nodegroup.parentnodegroup_id
-            for main_card in main_card_list:
-                if main_card.nodegroup_id == parent_obj:
+        for main_card in main_card_list:            
+            for sub_card in sub_card_list:
+                if main_card.nodegroup_id == sub_card.nodegroup.parentnodegroup_id:
                     index_number = main_card_list.index(main_card) + 1
                     main_card_list.insert(index_number, sub_card)
 


### PR DESCRIPTION
Search exports - CSV, HTML and ShapeFiles - are not generating on dev or stage. Server 500 error when dowloading smaller exports and task error appears in notifications for HTML and larger exports.