### PR TITLE
KH-R110 - Addition of app insights monitoring facility AB#51026

### DIFF
--- a/arches/app/templates/base.htm
+++ b/arches/app/templates/base.htm
@@ -50,6 +50,19 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <link href="{% static 'css/project.css' %}" rel="stylesheet">
     {% endblock css%}
 
+    <script type="text/javascript">
+        // ##### APPINSIGHTS MONITORING #####
+        var aikey = '#{appinsights-key}#';
+        if (/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(aikey) == true) {
+            console.log("aikey valid", aikey);
+            var appInsights = window.appInsights || function (a) { function b(a) { c[a] = function () { var b = arguments; c.queue.push(function () { c[a].apply(c, b) }) } } var c = { config: a }, d = document, e = window; setTimeout(function () { var b = d.createElement("script"); b.src = a.url || "https://az416426.vo.msecnd.net/scripts/a/ai.0.js", d.getElementsByTagName("script")[0].parentNode.appendChild(b) }); try { c.cookie = d.cookie } catch (a) { } c.queue = []; for (var f = ["Event", "Exception", "Metric", "PageView", "Trace", "Dependency"]; f.length;)b("track" + f.pop()); if (b("setAuthenticatedUserContext"), b("clearAuthenticatedUserContext"), b("startTrackEvent"), b("stopTrackEvent"), b("startTrackPage"), b("stopTrackPage"), b("flush"), !a.disableExceptionTracking) { f = "onerror", b("_" + f); var g = e[f]; e[f] = function (a, b, d, e, h) { var i = g && g(a, b, d, e, h); return !0 !== i && c["_" + f](a, b, d, e, h), i } } return c }({ instrumentationKey: aikey }); window.appInsights = appInsights, appInsights.queue && 0 === appInsights.queue.length && appInsights.trackPageView();
+        }
+        else {
+            console.log("aikey not valid - app insights not instantiated");
+        }
+            //####################################
+    </script>    
+
 </head>
 
 <body {% block body_attributes %}class="scroll-y-auto"{% endblock %}>

--- a/arches/app/templates/errors/error_base.htm
+++ b/arches/app/templates/errors/error_base.htm
@@ -50,6 +50,19 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <link href="{% static 'css/project.css' %}" rel="stylesheet">
     {% endblock css%}
 
+    <script type="text/javascript">
+        // ##### APPINSIGHTS MONITORING #####
+        var aikey = '#{appinsights-key}#';
+        if (/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(aikey) == true) {
+            console.log("aikey valid", aikey);
+            var appInsights = window.appInsights || function (a) { function b(a) { c[a] = function () { var b = arguments; c.queue.push(function () { c[a].apply(c, b) }) } } var c = { config: a }, d = document, e = window; setTimeout(function () { var b = d.createElement("script"); b.src = a.url || "https://az416426.vo.msecnd.net/scripts/a/ai.0.js", d.getElementsByTagName("script")[0].parentNode.appendChild(b) }); try { c.cookie = d.cookie } catch (a) { } c.queue = []; for (var f = ["Event", "Exception", "Metric", "PageView", "Trace", "Dependency"]; f.length;)b("track" + f.pop()); if (b("setAuthenticatedUserContext"), b("clearAuthenticatedUserContext"), b("startTrackEvent"), b("stopTrackEvent"), b("startTrackPage"), b("stopTrackPage"), b("flush"), !a.disableExceptionTracking) { f = "onerror", b("_" + f); var g = e[f]; e[f] = function (a, b, d, e, h) { var i = g && g(a, b, d, e, h); return !0 !== i && c["_" + f](a, b, d, e, h), i } } return c }({ instrumentationKey: aikey }); window.appInsights = appInsights, appInsights.queue && 0 === appInsights.queue.length && appInsights.trackPageView();
+        }
+        else {
+            console.log("aikey not valid - app insights not instantiated");
+        }
+            //####################################
+    </script>
+    
 </head>
 
 <body {% block body_attributes %}class="scroll-y-hidden"{% endblock %}>


### PR DESCRIPTION
Bug 51026 : KEY: Application Insights code missing from base.htm and error_base.htm

Branch from keystone/main (arches)

Go to any page that uses the Base view.

Actual Results
No metrics are being reported outside of the index page.

Expected Results
Metrics are being recorded for all page views.

N.B. Required tweaks made to variable substitution in Keystone-config pipeline YML separately (https://hedev.visualstudio.com/Inventory/_git/keystone-config/pullrequest/4664).