### PR TITLE
KEY: (Side navigation) Add a link to the landing page.

### DIFF
--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -35,6 +35,16 @@
                                     
                                     <ul id="mainnav-menu" class="list-group">
 
+                                        <!-- Home. -->
+                                        <li>
+                                            <a href="/" data-bind="click:function () { navigate('/') }">
+                                                <i class="ti-home"></i>
+                                                <span class="menu-title">
+                                                    <strong>Home</strong>
+                                                </span>
+                                            </a>
+                                        </li>
+
                                         <!-- Tools -->
                                         <li class="list-header">{% trans "Tools" %}</li>
 

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -40,7 +40,7 @@
                                             <a href="/" data-bind="click:function () { navigate('/') }">
                                                 <i class="ti-home"></i>
                                                 <span class="menu-title">
-                                                    <strong>Home</strong>
+                                                    <strong>{% trans "Home" %}</strong>
                                                 </span>
                                             </a>
                                         </li>


### PR DESCRIPTION
#51442 - KEY: (Side navigation) Add a link to the landing page

Add a new link as the first item in the side navigation with the text "Home" and a house icon, that navigates the user back to the landing page.

**Acceptance Criteria section.**

- There is a link called "Home" as the first entry of the side navigation panel.
- The link uses a "house icon"
- The link navigates the user to "~/" (the default landing page)
- The link must be keyboard accessible.
- It must be accessible (check with WAVE and NVDA).