### PR TITLE
AB#50380 Search panel order

### DIFF
--- a/arches/app/media/css/accessibility.css
+++ b/arches/app/media/css/accessibility.css
@@ -610,7 +610,7 @@ div.search-facet-item:focus {
     }
 
     .card-form-preview-container:not(.map-manager-container .card-form-preview-container) {
-        height: calc(70vh - 155px);
+        height: calc(50vh - 75px);
         overflow-y: auto;
     }
 

--- a/arches/app/media/css/accessibility.css
+++ b/arches/app/media/css/accessibility.css
@@ -587,7 +587,7 @@ div.search-facet-item:focus {
 
 @media screen and (max-width: 1024px) {
     article.flexrow {
-        flex-direction: column-reverse;
+        flex-direction: column;
     }
 
     article .flex.search-map-container {

--- a/arches/app/templates/views/search.htm
+++ b/arches/app/templates/views/search.htm
@@ -8,7 +8,6 @@
 
 {% block main_content %}
     <article class="content-panel flexrow" data-bind="click:function() { menuActive(false); }, visible: true", style="display:none;">
-
         <section class="flex search-results-panel">
             <div class="search-attribute-widget">
                 <div class="search-dropdown" data-bind="component: {
@@ -65,7 +64,6 @@
                 </div>
             </div>
         </section>
-
 
         <section class="flex search-map-container">
             <!-- Title Block -->


### PR DESCRIPTION
To change the panel stacking order, on the search page, when viewing on smaller screens. Was left to right > bottom to top, now left to right > top to bottom.

Please note that further work will be required to adjust panel/filter heights in order to not have multiple scrollbars, this will be fixed when working on future fix for resolving scrolling/small panels issue, which will allow page height to be scrollable rather than being contained in fixed height containers.

I've included one small height change as this was causing other issues.