### PR TITLE
Uncontiguous skipd headers to bootstrap containers - AB#45403

### DIFF
--- a/arches/app/templates/views/components/search/search-export.htm
+++ b/arches/app/templates/views/components/search/search-export.htm
@@ -7,7 +7,9 @@
     <div class="search-export">
         <div class="instruction">
             <h2> {% trans "1. Format" %} </h2>
-            <h4> {% trans "Select the format you'd like for your export data. (tile excel and geojson formats require a resource type filter)" %} </h4>
+            <p class="container-fluid small">
+                {% trans "Select the format you'd like for your export data. (tile excel and geojson formats require a resource type filter)" %}
+            </p>
         </div>
         <div class="parameter">
             <div>
@@ -42,7 +44,9 @@
 
         <div class="instruction">
             <h2> {% trans "2. Coordinate Precision" %} </h2>
-            <h4> {% trans "Tell us how many decimal places of precision you'd like for geo-data results" %} </h4>
+            <p class="container-fluid small">
+                {% trans "Tell us how many decimal places of precision you'd like for geo-data results" %} 
+            </p>
         </div>
         <div class="parameter">
             <input type="number" class="form-control input-md widget-input precision" data-bind="textInput: precision" aria-label="Precision decimal places"></input>
@@ -50,7 +54,9 @@
         
         <div class="instruction">
             <h2> {% trans "3. Report Link" %} </h2>
-            <h4> {% trans "Only applicable to CSV and shapefile exports" %} </h4>
+            <p class="container-fluid small">
+                {% trans "Only applicable to CSV and shapefile exports" %} 
+            </p>
         </div>
         <div class="parameter">
             <div data-bind="component: { name: 'views/components/simple-switch', params: {value: reportlink, config:{ label: '{% trans "Include the report link in the export?" %}', subtitle: ''}}}"></div>
@@ -67,7 +73,9 @@
         <div>
             <div class="instruction">
                 <h2> {% trans "5. Email Address" %} </h2>
-                <h4> {% trans "This download may take some time.  Tell us where to email a download link to your results" %} </h4>
+                <p class="container-fluid small">
+                    {% trans "This download may take some time.  Tell us where to email a download link to your results" %}
+                </p>
             </div>
             <div class="parameter">
                 <input type="" class="form-control input-md widget-input" data-bind="textInput: emailInput" placeholder="No Email saved for User" aria-label="Email address for receiving download link"></input>


### PR DESCRIPTION
 - RELEASE CANDIDATE BRANCH - 
===================================
Against keystone/acc

[AB#45403](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/45403)

ONLY address the heading order in the search export panel if arches.

The issue in the details section will be done in a separate ticket.


url: https://keystone.historicengland.org.uk/search

Steps to Reproduce:
Navigate to Search page
Enable WAVE browser extension
Expected Result:
Heading levels should increase sequentially.

Actual Result:
5 skipped heading levels are present. 