### PR TITLE
Headings and Labels - 1 skipped heading level present - AB#45480

### DIFF
--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -446,7 +446,7 @@
                                 <!-- content gets inserted into this div -->
                                 <div class="ep-help-content"></div>
                                 <hr>
-                                <h5>{% trans "for more documentation, visit" %} <a href="https://arches.readthedocs.io/" target="_blank">arches.readthedocs.io <i class="fa fa-external-link-square" aria-hidden="true"></i></a></h5>
+                                <p class="h5">{% trans "for more documentation, visit" %} <a href="https://arches.readthedocs.io/" target="_blank">arches.readthedocs.io <i class="fa fa-external-link-square" aria-hidden="true"></i></a></p>
                             </div>
                         </div>
                         


### PR DESCRIPTION
based on keystone/acc
[AB#45480](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/45480)
url: [https://keystone.historicengland.org.uk/](https://keystone.historicengland.org.uk/keystone/plugins/active-consultations)

Steps to Reproduce:
Navigate to any page 
Enable WAVE browser extension
View alerts in details section
Expected Result:
Headings should increase sequentially through the page content (it is possible to jump from an h4 to an h2, but not from an h2 to an h4).

Actual Result:
A skipped heading level is present - 'for more documentation, visit arches.readthedocs.io' is designated as an h5, after an h1.