### PR TITLE
Side navigation - add home link - AB#51442

### DIFF
--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -35,6 +35,16 @@
                                     
                                     <ul id="mainnav-menu" class="list-group">
 
+                                        <!-- Home. -->
+                                        <li>
+                                            <a href="/" data-bind="click:function () { navigate('/') }">
+                                                <i class="ti-home"></i>
+                                                <span class="menu-title">
+                                                    <strong>{% trans "Home" %}</strong>
+                                                </span>
+                                            </a>
+                                        </li>
+
                                         <!-- Tools -->
                                         <li class="list-header">{% trans "Tools" %}</li>
 


### PR DESCRIPTION
RC BRANCH
--------------------------------
[AB#51442](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/51442) - KEY: (Side navigation) Add a link to the landing page

Add a new link as the first item in the side navigation with the text "Home" and a house icon, that navigates the user back to the landing page.

**Acceptance Criteria section.**

There is a link called "Home" as the first entry of the side navigation panel.
The link uses a "house icon"
The link navigates the user to "~/" (the default landing page)
The link must be keyboard accessible.
It must be accessible (check with WAVE and NVDA).