### PR TITLE
AB#47469 Resource editor breadcrumb arrow

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -13223,7 +13223,7 @@ ul.select2-choices:after {
     color: #fff;
 }
 
-.card-breadcrumbs a.toggle-tree {
+.card-breadcrumbs .toggle-tree {
     font-size: 13px;
 }
 

--- a/arches/app/templates/views/resource/editor.htm
+++ b/arches/app/templates/views/resource/editor.htm
@@ -180,8 +180,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
                     <div class="card-breadcrumbs">
 
-                        <a href="#" class="toggle-tree"><i class="ion-arrow-left-b"></i></a>
-                        <!--<span class="toggle-tree"><i class="ion-arrow-left-b"></i></span>-->
+                        <span class="toggle-tree"><i class="ion-arrow-left-b"></i></span>
 
                         <!-- ko foreach: { data: selectionBreadcrumbs(), as: 'crumb' } -->
                             <!-- ko if: crumb.tileid -->

--- a/arches/app/templates/views/resource/editor.htm
+++ b/arches/app/templates/views/resource/editor.htm
@@ -181,6 +181,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     <div class="card-breadcrumbs">
 
                         <a href="#" class="toggle-tree"><i class="ion-arrow-left-b"></i></a>
+                        <!--<span class="toggle-tree"><i class="ion-arrow-left-b"></i></span>-->
 
                         <!-- ko foreach: { data: selectionBreadcrumbs(), as: 'crumb' } -->
                             <!-- ko if: crumb.tileid -->


### PR DESCRIPTION
Fix to remove un-required link on initial breadcrumb arrow icon in the Resource Editor