### PR TITLE
All cards - Error Prevention - No warning message to prevent the user accidentally deleting a record - #AB46270

### DIFF
--- a/arches/app/media/js/viewmodels/card-component.js
+++ b/arches/app/media/js/viewmodels/card-component.js
@@ -209,39 +209,37 @@ define([
         };
 
         this.deleteTile = function() {
-            self.loading(true);
-            self.tile.deleteTile(function(response) {
-                self.loading(false);
-                params.pageVm.alert(
-                    new AlertViewModel(
-                        'ep-alert-red',
-                        response.responseJSON.title,
-                        response.responseJSON.message,
-                        null,
-                        function(){}
-                    )
+            params.pageVm.alert(            
+                new AlertViewModel(
+                    'ep-alert-red',
+                    'Are you sure you would like to delete this tile?',
+                    'All data created for this tile will be deleted.',
+                    function(){}, //does nothing when canceled
+                    function() {
+                        self.loading(true);
+                        self.tile.deleteTile(function(response) {
+                            self.loading(false);
+                            params.pageVm.alert(
+                                new AlertViewModel(
+                                    'ep-alert-red',
+                                    response.responseJSON.title,
+                                    response.responseJSON.message,
+                                    null,
+                                    function(){}
+                                )
+                            );
+                            if (params.form.onDeleteError) {
+                                params.form.onDeleteError(self.tile);
+                            }
+                        }, function() {
+                            self.loading(false);
+                            if (typeof self.onDeleteSuccess === 'function') self.onDeleteSuccess();
+                            if (params.form.onDeleteSuccess) {
+                                params.form.onDeleteSuccess(self.tile);
+                            }
+                        });
+                    })
                 );
-                if (params.form.onDeleteError) {
-                    params.form.onDeleteError(self.tile);
-                }
-            }, function() {
-                self.loading(false);
-                if (typeof self.onDeleteSuccess === 'function') self.onDeleteSuccess();
-                if (params.form.onDeleteSuccess) {
-                    params.form.onDeleteSuccess(self.tile);
-                }
-            });
-        };
-        
-        this.createParentAndChild = async (parenttile, childcard) => {
-            try{
-                const newSave = await self.card.saveParentTile(parenttile);
-                if(newSave){
-                    childcard.selected(true);
-                }
-            } catch (err){
-                console.log(err);
-            }
         };
 
         this.initialize();

--- a/arches/app/media/js/viewmodels/tile.js
+++ b/arches/app/media/js/viewmodels/tile.js
@@ -5,8 +5,8 @@ define([
     'knockout-mapping',
     'arches',
     'require',
-    'viewmodels/card',
-    'viewmodels/alert'
+    'viewmodels/alert',
+    'viewmodels/card'
 ], function($, _, ko, koMapping, arches, require, AlertViewModel) {
     /**
     * A viewmodel used for generic cards
@@ -73,7 +73,7 @@ define([
         this.provisionaledits = ko.observable(params.tile.provisionaledits);
         this.datatypeLookup = getDatatypeLookup(params);
         this.transactionId = params.transactionId;
-        this.alert = config.alert || ko.observable(null);
+        this.alert = params.alert||ko.observable(null);
 
         _.extend(this, {
             filter: filter,
@@ -245,8 +245,7 @@ define([
                 });
             },
             deleteTile: function(onFail, onSuccess) {
-                self.alert(
-                    new AlertViewModel(
+                this.alert(new AlertViewModel(
                         'ep-alert-red',
                         'Are you sure you would like to delete this tile?',
                         'All data created for this tile will be deleted.',

--- a/arches/app/media/js/viewmodels/tile.js
+++ b/arches/app/media/js/viewmodels/tile.js
@@ -5,9 +5,8 @@ define([
     'knockout-mapping',
     'arches',
     'require',
-    'viewmodels/alert',
     'viewmodels/card'
-], function($, _, ko, koMapping, arches, require, AlertViewModel) {
+], function($, _, ko, koMapping, arches, require) {
     /**
     * A viewmodel used for generic cards
     *
@@ -73,7 +72,6 @@ define([
         this.provisionaledits = ko.observable(params.tile.provisionaledits);
         this.datatypeLookup = getDatatypeLookup(params);
         this.transactionId = params.transactionId;
-        this.alert = params.alert||ko.observable(null);
 
         _.extend(this, {
             filter: filter,
@@ -245,32 +243,24 @@ define([
                 });
             },
             deleteTile: function(onFail, onSuccess) {
-                this.alert(new AlertViewModel(
-                        'ep-alert-red',
-                        'Are you sure you would like to delete this tile?',
-                        'All data created for this tile will be deleted.',
-                        function(){}, //does nothing when canceled
-                        function(onFail, onSuccess) {
-                            loading(true);
-                            $.ajax({
-                                type: "DELETE",
-                                url: arches.urls.tile,
-                                data: JSON.stringify(self.getData())
-                            }).done(function(response) {
-                                params.card.tiles.remove(self);
-                                selection(params.card);
-                                if (typeof onSuccess === 'function') {
-                                    onSuccess(response);
-                                }
-                            }).fail(function(response) {
-                                if (typeof onFail === 'function') {
-                                    onFail(response);
-                                }
-                            }).always(function(){
-                                loading(false);
-                            })
-                        })
-                );
+                loading(true);
+                $.ajax({
+                    type: "DELETE",
+                    url: arches.urls.tile,
+                    data: JSON.stringify(self.getData())
+                }).done(function(response) {
+                    params.card.tiles.remove(self);
+                    selection(params.card);
+                    if (typeof onSuccess === 'function') {
+                        onSuccess(response);
+                    }
+                }).fail(function(response) {
+                    if (typeof onFail === 'function') {
+                        onFail(response);
+                    }
+                }).always(function(){
+                    loading(false);
+                });
             }
         });
 

--- a/arches/app/media/js/viewmodels/tile.js
+++ b/arches/app/media/js/viewmodels/tile.js
@@ -5,8 +5,9 @@ define([
     'knockout-mapping',
     'arches',
     'require',
-    'viewmodels/card'
-], function($, _, ko, koMapping, arches, require) {
+    'viewmodels/card',
+    'viewmodels/alert'
+], function($, _, ko, koMapping, arches, require, AlertViewModel) {
     /**
     * A viewmodel used for generic cards
     *
@@ -72,6 +73,7 @@ define([
         this.provisionaledits = ko.observable(params.tile.provisionaledits);
         this.datatypeLookup = getDatatypeLookup(params);
         this.transactionId = params.transactionId;
+        this.alert = config.alert || ko.observable(null);
 
         _.extend(this, {
             filter: filter,
@@ -243,24 +245,33 @@ define([
                 });
             },
             deleteTile: function(onFail, onSuccess) {
-                loading(true);
-                $.ajax({
-                    type: "DELETE",
-                    url: arches.urls.tile,
-                    data: JSON.stringify(self.getData())
-                }).done(function(response) {
-                    params.card.tiles.remove(self);
-                    selection(params.card);
-                    if (typeof onSuccess === 'function') {
-                        onSuccess(response);
-                    }
-                }).fail(function(response) {
-                    if (typeof onFail === 'function') {
-                        onFail(response);
-                    }
-                }).always(function(){
-                    loading(false);
-                });
+                self.alert(
+                    new AlertViewModel(
+                        'ep-alert-red',
+                        'Are you sure you would like to delete this tile?',
+                        'All data created for this tile will be deleted.',
+                        function(){}, //does nothing when canceled
+                        function(onFail, onSuccess) {
+                            loading(true);
+                            $.ajax({
+                                type: "DELETE",
+                                url: arches.urls.tile,
+                                data: JSON.stringify(self.getData())
+                            }).done(function(response) {
+                                params.card.tiles.remove(self);
+                                selection(params.card);
+                                if (typeof onSuccess === 'function') {
+                                    onSuccess(response);
+                                }
+                            }).fail(function(response) {
+                                if (typeof onFail === 'function') {
+                                    onFail(response);
+                                }
+                            }).always(function(){
+                                loading(false);
+                            })
+                        })
+                );
             }
         });
 


### PR DESCRIPTION
url: [https://dev-keystone.historicengland.org.uk/](https://dev-keystone.historicengland.org.uk/settings/#main-content)

Although this has come up as an accessibility issue, it should go back as a core giveback feature due to the usability improvement and there should be no breaking changes by giving this straight back.

Steps to Reproduce:
Navigate to any page in Keystone containing cards (e.g. System Settings)
Attempt to delete any card.
Expected Result:
User should be presented with a warning message on pressing the 'Delete' button, asking them if they are sure they want to delete the record they have selected.

Actual Result:
No warning message on the user selecting 'Delete' button to prevent the user accidentally deleting a record.