### PR TITLE
Perform deletion verify at card-component level AB#46270

### DIFF
--- a/arches/app/media/js/viewmodels/card-component.js
+++ b/arches/app/media/js/viewmodels/card-component.js
@@ -209,28 +209,37 @@ define([
         };
 
         this.deleteTile = function() {
-            self.loading(true);
-            self.tile.deleteTile(function(response) {
-                self.loading(false);
-                params.pageVm.alert(
-                    new AlertViewModel(
-                        'ep-alert-red',
-                        response.responseJSON.title,
-                        response.responseJSON.message,
-                        null,
-                        function(){}
-                    )
+            params.pageVm.alert(            
+                new AlertViewModel(
+                    'ep-alert-red',
+                    'Are you sure you would like to delete this tile?',
+                    'All data created for this tile will be deleted.',
+                    function(){}, //does nothing when canceled
+                    function() {
+                        self.loading(true);
+                        self.tile.deleteTile(function(response) {
+                            self.loading(false);
+                            params.pageVm.alert(
+                                new AlertViewModel(
+                                    'ep-alert-red',
+                                    response.responseJSON.title,
+                                    response.responseJSON.message,
+                                    null,
+                                    function(){}
+                                )
+                            );
+                            if (params.form.onDeleteError) {
+                                params.form.onDeleteError(self.tile);
+                            }
+                        }, function() {
+                            self.loading(false);
+                            if (typeof self.onDeleteSuccess === 'function') self.onDeleteSuccess();
+                            if (params.form.onDeleteSuccess) {
+                                params.form.onDeleteSuccess(self.tile);
+                            }
+                        });
+                    })
                 );
-                if (params.form.onDeleteError) {
-                    params.form.onDeleteError(self.tile);
-                }
-            }, function() {
-                self.loading(false);
-                if (typeof self.onDeleteSuccess === 'function') self.onDeleteSuccess();
-                if (params.form.onDeleteSuccess) {
-                    params.form.onDeleteSuccess(self.tile);
-                }
-            });
         };
         
         this.createParentAndChild = async (parenttile, childcard) => {

--- a/arches/app/media/js/viewmodels/card-component.js
+++ b/arches/app/media/js/viewmodels/card-component.js
@@ -212,8 +212,8 @@ define([
             params.pageVm.alert(            
                 new AlertViewModel(
                     'ep-alert-red',
-                    'Are you sure you would like to delete this tile?',
-                    'All data created for this tile will be deleted.',
+                    'Item Deletion.',
+                    'Are you sure you would like to delete this item?',
                     function(){}, //does nothing when canceled
                     function() {
                         self.loading(true);


### PR DESCRIPTION
url: [https://dev-keystone.historicengland.org.uk/](https://dev-keystone.historicengland.org.uk/settings/#main-content)

Although this has come up as an accessibility issue, it should go back as a core giveback feature due to the usability improvement and there should be no breaking changes by giving this straight back.

Steps to Reproduce:
Navigate to any page in Keystone containing cards (e.g. System Settings)
Attempt to delete any card.
Expected Result:
User should be presented with a warning message on pressing the 'Delete' button, asking them if they are sure they want to delete the record they have selected.

Actual Result:
No warning message on the user selecting 'Delete' button to prevent the user accidentally deleting a record.