### PR TITLE
KEY: enterkey ko bindingHandler for global use alongside click - AB#50965

### DIFF
--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -73,7 +73,6 @@ define([
                         if (keyCode === 13) {   // Check if keypress is <enter>.
                             $(element).blur();
                             $(element).click();
-                            return true;    // Allow default action.
                         }
                         return true;    // Allow default action.
                     });

--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -71,7 +71,6 @@ define([
                     $(element).keypress(function (event) {
                         var keyCode = (event.which ? event.which : event.keyCode);
                         if (keyCode === 13) {   // Check if keypress is <enter>.
-                            $(element).blur();
                             $(element).click();
                         }
                         return true;    // Allow default action.

--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -64,8 +64,8 @@ define([
                 return window.location.pathname === "/search" || window.location.pathname === "/plugins/c8261a41-a409-4e45-b049-c925c28a57da";
             });
 
-            // Register binding of onEnterkey. e.g. <div data-bind="onEnterkey"> </div>
-            ko.bindingHandlers.onEnterkey = {
+            // Register binding of onEnterkeyClick. e.g. <div data-bind="onEnterkeyClick"> </div>
+            ko.bindingHandlers.onEnterkeyClick = {
                 init: function (element, valueAccessor) {
                     ko.utils.unwrapObservable(valueAccessor()); // Unwrap to get subscription.
                     $(element).keypress(function (event) {

--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -64,7 +64,7 @@ define([
                 return window.location.pathname === "/search" || window.location.pathname === "/plugins/c8261a41-a409-4e45-b049-c925c28a57da";
             });
 
-            // Register binding of onEnterkey. e.g. <div data-bind="onEnterkey: someValue"> </div>
+            // Register binding of onEnterkey. e.g. <div data-bind="onEnterkey"> </div>
             ko.bindingHandlers.onEnterkey = {
                 init: function (element, valueAccessor) {
                     ko.utils.unwrapObservable(valueAccessor()); // Unwrap to get subscription.

--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -64,6 +64,22 @@ define([
                 return window.location.pathname === "/search" || window.location.pathname === "/plugins/c8261a41-a409-4e45-b049-c925c28a57da";
             });
 
+            // Register binding of onEnterkey. e.g. <div data-bind="onEnterkey: someValue"> </div>
+            ko.bindingHandlers.onEnterkey = {
+                init: function (element, valueAccessor) {
+                    ko.utils.unwrapObservable(valueAccessor()); // Unwrap to get subscription.
+                    $(element).keypress(function (event) {
+                        var keyCode = (event.which ? event.which : event.keyCode);
+                        if (keyCode === 13) {   // Check if keypress is <enter>.
+                            $(element).blur();
+                            $(element).click();
+                            return true;    // Allow default action.
+                        }
+                        return true;    // Allow default action.
+                    });
+                }
+            };
+
             PageView.prototype.constructor.call(this, options);
             return this;
         }


### PR DESCRIPTION
To allow much easier support of the use of enter key to match click events, try to create a global "enterkey" binding that is added to the base-manager (and index??) that can then be used to bind to the same function as click.