### PR TITLE
Consultation Workflow Find Associated Application Areas Fix AB#50917

### DIFF
--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -351,13 +351,15 @@ def search_results(request, returnDsl=False):
     if for_export or pages:
         results = dsl.search(index=RESOURCES_INDEX, scroll="1m")
         scroll_id = results["_scroll_id"]
+        if pages and pages.isnumeric():
+            pages = int(pages)
         if not pages:
             if total <= settings.SEARCH_EXPORT_LIMIT:
                 pages = (total // settings.SEARCH_RESULT_LIMIT) + 1
             if total > settings.SEARCH_EXPORT_LIMIT:
                 pages = int(settings.SEARCH_EXPORT_LIMIT // settings.SEARCH_RESULT_LIMIT) - 1
-        if int(pages) > 1:
-            for page in range(int(pages)):
+        if pages > 1:
+            for page in range(pages):
                 results_scrolled = dsl.se.es.scroll(scroll_id=scroll_id, scroll="1m")
                 results["hits"]["hits"] += results_scrolled["hits"]["hits"]
     else:

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -356,7 +356,7 @@ def search_results(request, returnDsl=False):
                 pages = (total // settings.SEARCH_RESULT_LIMIT) + 1
             if total > settings.SEARCH_EXPORT_LIMIT:
                 pages = int(settings.SEARCH_EXPORT_LIMIT // settings.SEARCH_RESULT_LIMIT) - 1
-        if pages > 1:
+        if int(pages) > 1:
             for page in range(int(pages)):
                 results_scrolled = dsl.se.es.scroll(scroll_id=scroll_id, scroll="1m")
                 results["hits"]["hits"] += results_scrolled["hits"]["hits"]


### PR DESCRIPTION
Fixes the issue where finding application areas within a buffered area around a consultation geometry was not working.

[AB#50917](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/50917)