### PR TITLE
AB#40439 Tile Excel Export fix

### DIFF
--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -267,7 +267,7 @@ def export_results(request):
             exporter = SearchResultsExporter(search_request=request)
             export_files, export_info = exporter.export(format, report_link)
             wb = export_files[0]["outputfile"]
-            with NamedTemporaryFile() as tmp:
+            with NamedTemporaryFile(delete=bool(settings.DELETE_TEMP_EXCEL_EXPORT_FILE)) as tmp:
                 wb.save(tmp.name)
                 tmp.seek(0)
                 stream = tmp.read()

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -267,7 +267,7 @@ def export_results(request):
             exporter = SearchResultsExporter(search_request=request)
             export_files, export_info = exporter.export(format, report_link)
             wb = export_files[0]["outputfile"]
-            with NamedTemporaryFile(delete=bool(settings.DELETE_TEMP_EXCEL_EXPORT_FILE)) as tmp:
+            with NamedTemporaryFile(dir=settings.TILE_EXCEL_EXPORT_TEMP_DIRECTORY,delete=settings.TILE_EXCEL_EXPORT_TEMP_FILE_DELETE) as tmp:
                 wb.save(tmp.name)
                 tmp.seek(0)
                 stream = tmp.read()

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -135,6 +135,11 @@ ARCHES_NAMESPACE_FOR_DATA_EXPORT = "http://localhost:8000/"
 # ordered as seen in the resource cards or not.
 EXPORT_DATA_FIELDS_IN_CARD_ORDER = False
 
+# This is used to indicate whether temporary export files for Tile Excel Export should
+# be deleted or not
+
+DELETE_TEMP_EXCEL_EXPORT_FILE = True
+
 RDM_JSONLD_CONTEXT = {"arches": ARCHES_NAMESPACE_FOR_DATA_EXPORT}
 
 PREFERRED_COORDINATE_SYSTEMS = (

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -135,10 +135,14 @@ ARCHES_NAMESPACE_FOR_DATA_EXPORT = "http://localhost:8000/"
 # ordered as seen in the resource cards or not.
 EXPORT_DATA_FIELDS_IN_CARD_ORDER = False
 
-# This is used to indicate whether temporary export files for Tile Excel Export should
-# be deleted or not
+# The TILE_EXCEL_EXPORT_TEMP_DIRECTORY and TILE_EXCEL_EXPORT_TEMP_FILE_DELETE settings
+# are only required by Windows instances of an Arches installation to ensure a successful
+# generation of data export in tile excel format.
+# The files generated in TILE_EXCEL_EXPORT_TEMP_DIRECTORY when TILE_EXCEL_EXPORT_TEMP_FILE_DELETE
+# is set to False will need to be cleared out periodically.
 
-DELETE_TEMP_EXCEL_EXPORT_FILE = True
+TILE_EXCEL_EXPORT_TEMP_DIRECTORY = None
+TILE_EXCEL_EXPORT_TEMP_FILE_DELETE = True
 
 RDM_JSONLD_CONTEXT = {"arches": ARCHES_NAMESPACE_FOR_DATA_EXPORT}
 


### PR DESCRIPTION
Provides a workaround fix for the issue of producing a Tile Excel Export from versions of Keystone running on a Windows server.

[AB#40439](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/40439)

NB, IIS_IUSRS needs write access to the export location

NB There is a related pull request for this ticket against the keystone-config repository as a change has been made to settings_local.py: https://hedev.visualstudio.com/Inventory/_git/keystone-config/pullrequest/4882

**Dev Peer Reviewer:** @khodgkinson-he 
**Tester:** @Rehaan-Arif 
**Merge Approval Lead:** @aj-he 