### PR TITLE
AB#41348 Json-Ld fix : Omit Edge from Null Domain

### DIFF
--- a/arches/app/utils/data_management/resources/formats/rdffile.py
+++ b/arches/app/utils/data_management/resources/formats/rdffile.py
@@ -149,6 +149,11 @@ class RdfWriter(Writer):
             # Nothing to do here
             if pkg["r_uri"] is None and pkg["range_tile_data"] is None:
                 return
+            
+            # KH41348 - JSON-LD fails assert if domain node empty while range node has data. 
+            # Unknown!=Undefined, but reasonable substitution to omit edge from null domain.
+            if pkg["d_uri"] is None:
+                return
 
             # FIXME:  Why is this not in datatype.to_rdf()
 


### PR DESCRIPTION
Issue : JSON-LD concept model handling does not handle null domain nodes with data in the range node on rdffile.py edge relationship generation.

ArchesProject GitHub Giveback Issue : https://github.com/archesproject/arches-her/issues/870 


Fix : Do not parse null. Domain node as Undefined (omitted) substitution used for Unknown (NULL) throughout code and results.