### PR TITLE
Add 1000ms debouce for main term search

### DIFF
--- a/arches/app/media/js/bindings/term-search.js
+++ b/arches/app/media/js/bindings/term-search.js
@@ -31,6 +31,7 @@ define([
                 ajax: {
                     url: arches.urls.search_terms,
                     dataType: 'json',
+                    quietMillis: 1000,
                     data: function(term, page) {
                         return {
                             q: term, // search term


### PR DESCRIPTION
[AB#57798](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/57798)

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Add a 1000ms debounce on main term search select2 control. This came out of performance testing to reduce search requests getting sent to Elastic.

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @RobOatesHistoricEngland 
*   Tested by: @RobOatesHistoricEngland 
*   Designed by: @RobOatesHistoricEngland 