### PR TITLE
AB#59047 Renamed Variable to avoid overwrite

### DIFF
--- a/arches/app/views/user.py
+++ b/arches/app/views/user.py
@@ -179,12 +179,12 @@ class UserManagerView(BaseManagerView):
                 try:
                     admin_info = settings.ADMINS[0][1] if settings.ADMINS else None
 
-                    user = ""
+                    user_name = ""
 
                     if request.user.first_name != "":
-                        user = request.user.first_name
+                        user_name = request.user.first_name
                     else:
-                        user = request.user.username
+                        user_name = request.user.username
 
                     message = (
                         f"Your {settings.APP_NAME} profile was just changed.  If this was unexpected, please contact your "
@@ -192,7 +192,7 @@ class UserManagerView(BaseManagerView):
                     )
                     message = _(message)
 
-                    email_context = return_message_context(message,"",None,{"username":user})
+                    email_context = return_message_context(message,"",None,{"username":user_name})
 
                     html_content = render_to_string("email/general_notification.htm", email_context)  # ...
                     text_content = strip_tags(html_content)  # this strips the html, so people will have the text as well.


### PR DESCRIPTION
### BUGFIX : [AB#59047](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/59047) : Updating account details causes Server Error (500)
Given I am logged in as an admin on stage/dev
And I am on the homepage
And I click on 'Welcome, <username>'
When I edit my account details such as changing my name or email
And I click on the save button 

Expected Results: The changes save successfully and you receive a verification email

Actual Results: The page refreshes and you get a Server Error (500) but you do still receive a verification email