### PR TITLE
Fixes timefilter compare bug AB#59061

### DIFF
--- a/arches/app/media/js/views/components/search/time-filter.js
+++ b/arches/app/media/js/views/components/search/time-filter.js
@@ -188,6 +188,9 @@ function($, _, ko, moment, BaseFilter, arches) {
             createNumericYMD: function(dateString, isToDate = false){
 
                 let ymd = dateString.split('-');
+                if(ymd.length == 0){
+                    ymd[0] = dateString;
+                }
                 if (dateString.charAt(0) == "y" || dateString.charAt(0) == "Y") ymd.shift();
                 if (dateString.charAt(0) == "-"){
                   ymd.shift();

--- a/arches/app/media/js/views/components/search/time-filter.js
+++ b/arches/app/media/js/views/components/search/time-filter.js
@@ -158,23 +158,40 @@ function($, _, ko, moment, BaseFilter, arches) {
                 }
             },
 
-            isFromLessThanTo: function(fromDate, toDate) {
-                if(!this.isBCE(fromDate) && !this.isBCE(toDate)) {
-                    return fromDate < toDate;
-                }else if(this.isBCE(fromDate) && !this.isBCE(toDate)) {
-                    return true;
-                }else if(!this.isBCE(fromDate) && this.isBCE(toDate)) {
-                    return false;
-                }else if(this.isBCE(fromDate) && this.isBCE(toDate)) {
-                    return fromDate > toDate;
-                }
+            isFromLessThanTo: function(fromDate, toDate) {  
+                let fromYMD = this.createNumericYMD(fromDate);
+                let toYMD = this.createNumericYMD(toDate);
+                return this.isFromYMDLessEqualThanToYMD(fromYMD, toYMD);
+            },
+                
+            createNumericYMD: function(dateString, toEnd = false){
+
+                let ymd = dateString.split('-');
+                if (dateString.charAt(0) == "-"){
+                  ymd.shift();
+                  ymd[0] = parseInt("-" + ymd[0]);
+                }  
+                ymd[1] = parseInt(ymd[1]) || (toEnd==true ? 12 : 1);
+                ymd[2] = parseInt(ymd[2]) || (toEnd==true ? (new Date(ymd[0], ymd[1], 0)).getDate() : 1);
+                return ymd;
+            },
+              
+            isFromYMDLessEqualThanToYMD: function(fromYMD, toYMD){
+   
+                if (fromYMD[0] > toYMD[0]) return false;
+                if (fromYMD[1] > toYMD[1]) return false;
+                if (fromYMD[2] > toYMD[2]) return false;
+        
                 return true;
+                  
             },
-
-            isBCE: function(date) {
-                return (date.charAt(0) === '-');
+            //TODO: use this in this.filter.fromDate/toDate.subscribe to validate date string and return error message. apply after accessibility added in 7.5
+            //      so that error message can be read by screen reader etc.
+            validateDateString: function(dateString){
+                let dateRegex = /^-?\d{1,8}(-\d{1,2}(-\d{1,2})?)?$/;
+                return dateRegex.test(dateString);
             },
-
+            
             clear: function() {
                 this.filter.fromDate(null);
                 this.filter.toDate(null);

--- a/arches/app/media/js/views/components/search/time-filter.js
+++ b/arches/app/media/js/views/components/search/time-filter.js
@@ -24,15 +24,27 @@ function($, _, ko, moment, BaseFilter, arches) {
                     inverted: ko.observable(false)
                 };
                 this.filter.fromDate.subscribe(function (fromDate) {
-                    var toDate = this.filter.toDate();
-                    if (fromDate && toDate && !this.isFromLessThanTo(fromDate, toDate)) {
-                        this.filter.toDate(fromDate);
+                    const parsedfromDate = this.parseGreaterThan4DigitYear(fromDate);
+                    if (parsedfromDate !== fromDate) {
+                        this.filter.fromDate(parsedfromDate);
+                    }
+                    else {
+                        var toDate = this.filter.toDate();
+                        if (fromDate && toDate && !this.isFromLessThanTo(fromDate, toDate)) {
+                            this.filter.toDate(fromDate);
+                        }
                     }
                 }, this);
                 this.filter.toDate.subscribe(function (toDate) {
-                    var fromDate = this.filter.fromDate();
-                    if (fromDate && toDate && !this.isFromLessThanTo(fromDate, toDate)) {
-                        this.filter.fromDate(toDate);
+                    const parsedToDate = this.parseGreaterThan4DigitYear(toDate, true);
+                    if (parsedToDate !== toDate) {
+                        this.filter.toDate(parsedToDate);
+                    }
+                    else {
+                        var fromDate = this.filter.fromDate();
+                        if (fromDate && toDate && !this.isFromLessThanTo(fromDate, toDate)) {
+                            this.filter.fromDate(toDate);
+                        }
                     }
                 }, this);
                 this.dateRangeType = ko.observable('custom');
@@ -160,19 +172,29 @@ function($, _, ko, moment, BaseFilter, arches) {
 
             isFromLessThanTo: function(fromDate, toDate) {  
                 let fromYMD = this.createNumericYMD(fromDate);
-                let toYMD = this.createNumericYMD(toDate);
+                let toYMD = this.createNumericYMD(toDate, true);
                 return this.isFromYMDLessEqualThanToYMD(fromYMD, toYMD);
             },
+
+            parseGreaterThan4DigitYear: function(dateString, isToDate = false){
+                if (dateString === undefined || dateString === null || dateString === "") return dateString;
+                let ymd = this.createNumericYMD(dateString, isToDate);
+                let ymdYear = ymd[0];
+                if (ymdYear < -9999 || ymdYear > 9999) return ymdYear.toString();
                 
-            createNumericYMD: function(dateString, toEnd = false){
+                return dateString;
+            },
+                
+            createNumericYMD: function(dateString, isToDate = false){
 
                 let ymd = dateString.split('-');
+                if (dateString.charAt(0) == "y" || dateString.charAt(0) == "Y") ymd.shift();
                 if (dateString.charAt(0) == "-"){
                   ymd.shift();
                   ymd[0] = parseInt("-" + ymd[0]);
                 }  
-                ymd[1] = parseInt(ymd[1]) || (toEnd==true ? 12 : 1);
-                ymd[2] = parseInt(ymd[2]) || (toEnd==true ? (new Date(ymd[0], ymd[1], 0)).getDate() : 1);
+                ymd[1] = parseInt(ymd[1]) || (isToDate==true ? 12 : 1);
+                ymd[2] = parseInt(ymd[2]) || (isToDate==true ? (new Date(ymd[0], ymd[1], 0)).getDate() : 1);
                 return ymd;
             },
               

--- a/arches/app/media/js/views/search.js
+++ b/arches/app/media/js/views/search.js
@@ -5,10 +5,11 @@ define([
     'knockout-mapping',
     'arches',
     'viewmodels/alert',
+    'viewmodels/alert-json',
     'search-components',
     'views/base-manager',
     'views/components/simple-switch'
-], function($, _, ko, koMapping, arches, AlertViewModel, SearchComponents, BaseManagerView) {
+], function($, _, ko, koMapping, arches, AlertViewModel, JsonErrorAlertViewModel, SearchComponents, BaseManagerView) {
     // a method to track the old and new values of a subscribable
     // from https://github.com/knockout/knockout/issues/914
     //
@@ -164,7 +165,14 @@ define([
                 },
                 error: function(response, status, error) {
                     if(this.updateRequest.statusText !== 'abort'){
-                        this.viewModel.alert(new AlertViewModel('ep-alert-red', arches.requestFailed.title, response.responseText));
+                        
+                        try {
+                            this.viewModel.alert(new JsonErrorAlertViewModel('ep-alert-red', response.responseJSON));
+                        }
+                        catch(err) {
+                            this.viewModel.alert(new AlertViewModel('ep-alert-red', arches.requestFailed.title, response.responseText));
+                        }
+                        
                     }
                 },
                 complete: function(request, status) {

--- a/arches/app/search/components/time_filter.py
+++ b/arches/app/search/components/time_filter.py
@@ -6,6 +6,7 @@ from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.search.elasticsearch_dsl_builder import Bool, Nested, Term, Terms, Range
 from arches.app.search.components.base import BaseSearchFilter
 from django.db.models import Q
+from django.utils.translation import ugettext as _
 
 details = {
     "searchcomponentid": "",
@@ -31,10 +32,10 @@ class TimeFilter(BaseSearchFilter):
             start_date = ExtendedDateFormat(temporal_filter["fromDate"])
             end_date = ExtendedDateFormat(temporal_filter["toDate"])
 
-            if start_date.is_valid() is False:
-                raise Exception("Invalid time filter From Date: " + temporal_filter["fromDate"])
-            if end_date.is_valid() is False:
-                raise Exception("Invalid time filter To Date: " + temporal_filter["toDate"])
+            if start_date.is_valid() is False and temporal_filter["fromDate"] is not None:
+                raise ValueError(_("Invalid time filter From Date: ") + temporal_filter["fromDate"])
+            if end_date.is_valid() is False and temporal_filter["toDate"] is not None:
+                raise ValueError(_("Invalid time filter To Date: ") + temporal_filter["toDate"])
 
             date_nodeid = (
                 str(temporal_filter["dateNodeId"]) if "dateNodeId" in temporal_filter and temporal_filter["dateNodeId"] != "" else None

--- a/arches/app/search/components/time_filter.py
+++ b/arches/app/search/components/time_filter.py
@@ -30,6 +30,12 @@ class TimeFilter(BaseSearchFilter):
             # now = str(datetime.utcnow())
             start_date = ExtendedDateFormat(temporal_filter["fromDate"])
             end_date = ExtendedDateFormat(temporal_filter["toDate"])
+
+            if start_date.is_valid() is False:
+                raise Exception("Invalid time filter start date: " + temporal_filter["fromDate"])
+            if end_date.is_valid() is False:
+                raise Exception("Invalid time filter end date: " + temporal_filter["toDate"])
+
             date_nodeid = (
                 str(temporal_filter["dateNodeId"]) if "dateNodeId" in temporal_filter and temporal_filter["dateNodeId"] != "" else None
             )

--- a/arches/app/search/components/time_filter.py
+++ b/arches/app/search/components/time_filter.py
@@ -32,9 +32,9 @@ class TimeFilter(BaseSearchFilter):
             end_date = ExtendedDateFormat(temporal_filter["toDate"])
 
             if start_date.is_valid() is False:
-                raise Exception("Invalid time filter start date: " + temporal_filter["fromDate"])
+                raise Exception("Invalid time filter From Date: " + temporal_filter["fromDate"])
             if end_date.is_valid() is False:
-                raise Exception("Invalid time filter end date: " + temporal_filter["toDate"])
+                raise Exception("Invalid time filter To Date: " + temporal_filter["toDate"])
 
             date_nodeid = (
                 str(temporal_filter["dateNodeId"]) if "dateNodeId" in temporal_filter and temporal_filter["dateNodeId"] != "" else None

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -333,7 +333,7 @@ def search_results(request, returnDsl=False):
         append_instance_permission_filter_dsl(request, search_results_object)
     except Exception as err:
         logger.exception(err)
-        return JSONErrorResponse(message=err)
+        return JSONErrorResponse(content={"title": _("There was an error fetching search results."), "message": str(err)})
 
     dsl = search_results_object.pop("query", None)
     if returnDsl:


### PR DESCRIPTION
Fixes [AB#59061](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/59061). Please use the detail in ticket #9784 for testing.

In the time filter, **From Date** and **To Date** values are now correctly compared dates as numbers rather than as strings.

The solution also includes a validation function to be implemented at a later date once the accessibility work has been merged into Arches. This was used during testing for this ticket so worth including - have added a TODO note to state why it is not yet implemented.
