### PR TITLE
Migration from 5.2 to 6.2 runs out of memory

### DIFF
--- a/arches/app/models/migrations/6020_bi_directional_node_to_resource.py
+++ b/arches/app/models/migrations/6020_bi_directional_node_to_resource.py
@@ -19,7 +19,7 @@ def setup(apps):
     }
     resource_instance_tiles = tiles.objects.filter(
         Q(nodegroup_id__node__datatype="resource-instance") | Q(nodegroup_id__node__datatype="resource-instance-list")
-    ).distinct()
+    ).distinct().iterator(chunk_size=1000)
     root_ontology_classes = {
         str(node["graph_id"]): node["ontologyclass"] for node in nodes.objects.filter(istopnode=True).values("graph_id", "ontologyclass")
     }

--- a/arches/app/models/migrations/6481_add_resourceinstance_graphid.py
+++ b/arches/app/models/migrations/6481_add_resourceinstance_graphid.py
@@ -37,12 +37,8 @@ class Migration(migrations.Migration):
                 print("Updated {} rows".format(counter))
                 modified_rows = []
                 
-
         if len(modified_rows) > 0:
             ResourceXResource.objects.using(db_alias).bulk_update(modified_rows, ["resourceinstanceto_graphid","resourceinstancefrom_graphid"])
-            counter += len(modified_rows)
-        
-        print("finished updating {} rows".format(counter))
 
     operations = [
         migrations.AddField(

--- a/arches/app/models/migrations/6481_add_resourceinstance_graphid.py
+++ b/arches/app/models/migrations/6481_add_resourceinstance_graphid.py
@@ -29,8 +29,6 @@ class Migration(migrations.Migration):
             except:
                 pass
             
-            #row.save()
-
             modified_rows.append(row)
 
             if len(modified_rows) == batch_size:


### PR DESCRIPTION
Fixes the issues migrating Warden from 5.2 to 6.2 of Arches.

Test run completed successfully by @aj-he and @khodgkinson-he 