### PR TITLE
AB#61880 Tabbed reports accessibility

### DIFF
--- a/arches/app/media/css/accessibility.css
+++ b/arches/app/media/css/accessibility.css
@@ -121,7 +121,8 @@ a:focus,
 .hover-feature-metadata,
 .pagination > li > a.disabled,
 .graph-designer-header,
-.graph-type {
+.graph-type,
+.report-tab i {
     color: #595959;
 }
 
@@ -654,6 +655,11 @@ a#menu-toggle:focus {
 
 .change-password-form .error-message-container {
     display: inline-flex;
+}
+
+.tab-banner,
+.report-tab.active {
+    background: #1E5A8F;
 }
 
 /******************************************************************/

--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -1290,7 +1290,6 @@ ul.tabbed-report-tab-list {
     font-size: 19px;
     line-height: 23px;
     display: block;
-    margin: 0 4px;
     text-align: center;
     padding: 13px;
 }

--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -1260,9 +1260,6 @@ div.wf-multi-tile-card-info div {
     flex-direction: row;
     list-style-type: none;
     flex-wrap: wrap;
-}
-
-ul.tabbed-report-tab-list {
     margin: 0;
     padding: 0 20px;
 }

--- a/arches/app/templates/views/components/cards/default-card-report.htm
+++ b/arches/app/templates/views/components/cards/default-card-report.htm
@@ -3,10 +3,16 @@
 
 <div data-bind="css: {'print-hide': !reportExpanded()}">
     <!-- ko if: showHeaderLine--><hr class="rp-tile-separator"><!-- /ko -->
-    <div class="rp-card-section" data-bind="css: card.model.cssclass, visible: card.fullyProvisional() !== 'fullyprovisional'">
+    <div class="rp-card-section" data-bind="css: card.model.cssclass, visible: card.fullyProvisional() !== 'fullyprovisional', let: {uid: Math.random().toString(16).slice(2)}">
         <span class="rp-tile-title" data-bind="text: card.model.get('name')"></span>
         <!-- ko if: card.tiles().length > 0 -->
-        <i class="fa report-expander print-hide" tabindex="0" data-bind="css: {'fa-angle-down': reportExpanded(), 'fa-angle-right': !reportExpanded()}, attr: {'aria-label': 'Expand/collapse'}, click: function () { reportExpanded(!reportExpanded()) }" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></i>
+        <i class="fa report-expander print-hide"
+            tabindex="0"
+            data-bind="css: {'fa-angle-down': reportExpanded(), 'fa-angle-right': !reportExpanded()}, attr: {'aria-label': 'Expand/collapse', 'aria-controls': uid, 'aria-expanded': !reportExpanded() ? 'false' : 'true'}, click: function () { reportExpanded(!reportExpanded()) }"
+            onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"
+            aria-expanded="true"
+            ></i>
+        <div data-bind="attr: {'id': uid}">
         <!-- ko if: reportExpanded() -->
         <!-- ko foreach: { data: self.preview ? [card.newTile] : card.tiles, as: 'tile' } -->
 
@@ -77,7 +83,7 @@
                     {% endblock report_cards %}
                 </div>
             <!-- /ko -->
-            <!-- /ko -->
+            <!-- /ko --></div>
             <!-- /ko -->
 
         <!-- ko if: card.tiles().length === 0 && !self.preview && !card.hideEmptyNodes -->

--- a/arches/app/templates/views/report-templates/tabbed.htm
+++ b/arches/app/templates/views/report-templates/tabbed.htm
@@ -5,13 +5,15 @@
 {% block header %}
 <!-- ko if: tabs()[activeTabIndex()]  -->
 <div>
-    <ul class="tabbed-report-tab-list">
-    <!-- ko foreach: {data: tabs, as: 'tab'}  -->
-    <li tabindex="0" data-bind="click: function(){ $parent.setActiveTab($index()) }, css: { 'active': ko.unwrap($parent.activeTabIndex) === $index() }" class="report-tab" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
-        <span><i data-bind="attr: {class: ('fa '+ ko.unwrap(tab.icon)), 'aria-label': 'Display '+ko.unwrap(tab.name)+' information'}"></i></span>
-    </li>
-    <!-- /ko -->
-</ul>
+    <div class="tabbed-report-tab-list" role="tablist">
+        <!-- ko foreach: {data: tabs, as: 'tab'}  -->
+        <div data-bind="let: {tabuid: Math.random().toString(16).slice(2)}">
+            <div tabindex="0" data-bind="click: function(){ $parent.setActiveTab($index()); document.querySelector('.rp-tabpanel-id').setAttribute('id', tabuid); }, css: { 'active': ko.unwrap($parent.activeTabIndex) === $index() }, attr: { 'aria-expanded': ko.unwrap($parent.activeTabIndex) === $index() ? 'true' : 'false', 'aria-controls': tabuid }" class="report-tab" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" role="tab">
+                <span><i data-bind="attr: {class: ('fa '+ ko.unwrap(tab.icon)), 'aria-label': 'Display '+ko.unwrap(tab.name)+' information'}"></i></span>
+            </div>
+        </div>
+        <!-- /ko -->
+    </div>
 </div>
 <div class="tab-banner">
     <div style="display: flex; flex-direction: row">
@@ -38,7 +40,7 @@
 {% block header_form %}
 <div style="display: flex; flex-direction: row">
 <div id="card-save-tile-btn" class="install-buttons">
-    <button id="" class="btn btn-shim btn-mint btn-labeled btn-md fa fa-plus" data-bind="click: addTab">{% trans "Add Tab" %}</button>
+    <button class="btn btn-shim btn-mint btn-labeled btn-md fa fa-plus" data-bind="click: addTab">{% trans "Add Tab" %}</button>
 </div>
 </div>
 <div data-bind="sortable: {
@@ -54,7 +56,7 @@
         </div>
         <div>
             <div class="col-xs-12 pad-nor" style="padding: 5px">
-                <input type="" placeholder="{% trans "Tab Name" %}" id="" class="form-control input-md widget-input" data-bind="textInput: tab.name" />
+                <input type="" placeholder="{% trans "Tab Name" %}" class="form-control input-md widget-input" data-bind="textInput: tab.name" />
             </div>
             <div class="col-xs-12 pad-nor" style="padding: 5px">
                 <!--ko if: $parent.icons().length > 0 -->
@@ -104,7 +106,7 @@
     }"></div>
     <!--/ko-->
     <!-- ko if: !tabs()[activeTabIndex()].empty_component || !activeTabEmpty()  -->
-    <div class="rp-report-section relative rp-report-section-root">
+    <div id="" class="rp-report-section relative rp-report-section-root rp-tabpanel-id" role="tabpanel" aria-live="polite">
         <!-- ko if: tabs()[activeTabIndex()].side_component  -->
         <div class="tabbed-report-sidepanel-wrapper">
             <div class="tabbed-report-sidepanel" data-bind="component: {

--- a/arches/app/templates/views/report-templates/tabbed.htm
+++ b/arches/app/templates/views/report-templates/tabbed.htm
@@ -7,7 +7,7 @@
 <div>
     <ul class="tabbed-report-tab-list">
     <!-- ko foreach: {data: tabs, as: 'tab'}  -->
-    <li data-bind="click: function(){ $parent.setActiveTab($index()) }, css: { 'active': ko.unwrap($parent.activeTabIndex) === $index() }" class="report-tab">
+    <li tabindex="0" data-bind="click: function(){ $parent.setActiveTab($index()) }, css: { 'active': ko.unwrap($parent.activeTabIndex) === $index() }" class="report-tab" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
         <a><span><i data-bind="attr: {class: ('fa '+ ko.unwrap(tab.icon))}"></i></span></a>
     </li>
     <!-- /ko -->

--- a/arches/app/templates/views/report-templates/tabbed.htm
+++ b/arches/app/templates/views/report-templates/tabbed.htm
@@ -8,7 +8,7 @@
     <ul class="tabbed-report-tab-list">
     <!-- ko foreach: {data: tabs, as: 'tab'}  -->
     <li tabindex="0" data-bind="click: function(){ $parent.setActiveTab($index()) }, css: { 'active': ko.unwrap($parent.activeTabIndex) === $index() }" class="report-tab" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
-        <a><span><i data-bind="attr: {class: ('fa '+ ko.unwrap(tab.icon))}"></i></span></a>
+        <span><i data-bind="attr: {class: ('fa '+ ko.unwrap(tab.icon)), 'aria-label': 'Display '+ko.unwrap(tab.name)+' information'}"></i></span>
     </li>
     <!-- /ko -->
 </ul>


### PR DESCRIPTION
### Types of changes
-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change

[AB#61880](https://dev.azure.com/hedev/Inventory/_workitems/edit/61880)

Ensure that the tabs in the Tabbed Report template are accessible so that:

- They are tab-able
- Icon colours are contrast compliant
- Their title is read and state is read out
- Making a tab active reads out that the active tab is now XYZ tab.

Peer Review: @RobOatesHistoricEngland 
Tester: @gouthamrandhi or Jamie McMinn
Merge Lead: @aj-he 
