### PR TITLE
AB#71899 Change <h3> element to <span>

### DIFF
--- a/arches/app/templates/views/search.htm
+++ b/arches/app/templates/views/search.htm
@@ -37,7 +37,7 @@
                     <div class="col-xs-6">
                         <!-- Result Count and ordering Block -->
                         <div class="search-count-container">
-                            <h3 class="search-title" data-bind="text: '{% trans 'Results: ' %}' + total()"></h3>
+                            <span class="search-title" data-bind="text: '{% trans 'Results: ' %}' + total()"></span>
                         </div>
                     </div>
                     <div class="col-xs-6">


### PR DESCRIPTION
[AB#71899](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/71899)

### Description of Change
The screen reader goes from a `<h1>` to a `<h3>` which could be confusing as there is no intervening `<h2>`. Semantically this is not such a problem, but there is no need for the results count element to be a heading at all.

Changed the `<h3>` element to a `<span>` as the styling was set by the `search-title` class, not the element type.