### PR TITLE
AB#71954 Remove previously required positive tabindex on skip link

### DIFF
--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -7,7 +7,7 @@
 
     <div class="wrapper">
 
-        <div id="skip-link-holder"><a id="skip-link" tabindex="1" href="#skiptocontent">Skip to content</a></div>
+        <div id="skip-link-holder"><a id="skip-link" href="#skiptocontent">Skip to content</a></div>
 
         <div id="container" class="effect aside-left aside-bright navbar-fixed mainnav-sm" data-bind="css: {'mainnav-in': tabsActive() && showTabs(), 'mainnav-sm': !navExpanded(), 'mainnav-lg': navExpanded()}">
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
[AB#71954](https://dev.azure.com/hedev/Inventory/_workitems/edit/71954)

This change removes a previously required tabindex="1" on the skip link in the base manager template.

With this removed, the first tabbable item is still the skip link. Previously there were some other elements in the natural DOM tab order.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#298 

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @phudson-he 
*   Tested by: @phudson-he 
*   Designed by: @phudson-he 
