### PR TITLE
Changes result list link from <h3> to <p> AB#71899

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -22,6 +22,36 @@
 @import url(../packages/@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css);
 @import url(../packages/leaflet.fullscreen/Control.FullScreen.css);
 
+
+//adds heading tag classes to help with styling Can be removed from 7.5 onwards
+.h1 {
+    font-size: 34px
+}
+
+.h2 {
+    font-size: 28px
+}
+
+.h3 {
+    font-size: 22px
+}
+
+.h4 {
+    font-size: 16px
+}
+
+.h5 {
+    font-size: 12px
+}
+
+.h6 {
+    font-size: 10px
+}
+
+.h1,.h2,.h3,.h4,.h5,.h6 {
+    font-weight: 600
+}
+
 #skip-link-holder a, #skip-link-holder a:link, #skip-link-holder a:visited {
     color: #000;
     background-color: #fae619;
@@ -11724,6 +11754,10 @@ table.table.dataTable {
 
 .search-export .instruction {
     font-size: 15px;
+}
+.search-export-instruction-h2 {
+    font-size: 15px;
+    margin-top: 5px;
 }
 
 .search-export .instruction h2 {

--- a/arches/app/templates/views/components/search/advanced-search.htm
+++ b/arches/app/templates/views/components/search/advanced-search.htm
@@ -5,7 +5,7 @@
     <div class="facets-container" style="">
         <div class="list-group search-facets">
             <div class="search-facet-item header">
-                <h4 class="search-facet-item-heading">{% trans "Search Facets" %}</h4>
+                <p class="search-facet-item-heading h4">{% trans "Search Facets" %}</p>
                 <div class="list-filter relative">
                     <input type="text" class="form-control" placeholder="{% trans "Find ..." %}" aria-label="{% trans "Find search facets" %}" data-bind="value: facetFilterText, valueUpdate: 'keyup'">
                     <!-- Clear Filter -->
@@ -16,16 +16,16 @@
             <!-- ko foreach: searchableGraphs -->
             <!-- ko if: cards().length > 0  -->
             <div class="search-facet-item disabled">
-                <h4 class="search-facet-item-heading" data-bind="click: function () { collapsed(!collapsed()) }">
+                <p class="search-facet-item-heading h4" data-bind="click: function () { collapsed(!collapsed()) }">
                     <strong data-bind="text: name"></strong>
                     <span><i class="fa report-expander print-hide"
                             data-bind="css: {'fa-angle-down': !collapsed(), 'fa-angle-right': collapsed()}"></i></span>
-                </h4>
+                </p>
             </div>
             <div data-bind="visible: !collapsed()">
                 <!-- ko foreach: cards -->
                 <a href="#" class="search-facet-item" data-bind="click: addFacet">
-                    <h4 class="search-facet-item-heading" data-bind="text: name"></h4>
+                    <p class="search-facet-item-heading h4" data-bind="text: name"></p>
                     <p class="list-group-item-text"></p>
                 </a>
                 <!-- /ko -->

--- a/arches/app/templates/views/components/search/advanced-search.htm
+++ b/arches/app/templates/views/components/search/advanced-search.htm
@@ -15,21 +15,26 @@
             </div>
             <!-- ko foreach: searchableGraphs -->
             <!-- ko if: cards().length > 0  -->
-            <div class="search-facet-item disabled">
-                <p class="search-facet-item-heading h4" data-bind="click: function () { collapsed(!collapsed()) }">
+            <!-- ko let: {uid: Math.random().toString()} -->
+            <div tabindex="0" role="button" class="search-facet-item disabled" data-bind="onEnterkeyClick, onSpaceClick, click: function () { collapsed(!collapsed()) }, attr: {
+                        'aria-expanded': (!collapsed()).toString(),
+                        'aria-controls': uid,
+                        'aria-label': name + ' graph facets',
+                    }">
+                <div class="search-facet-item-heading h4" >
                     <strong data-bind="text: name"></strong>
                     <span><i class="fa report-expander print-hide"
                             data-bind="css: {'fa-angle-down': !collapsed(), 'fa-angle-right': collapsed()}"></i></span>
-                </p>
+                </div>
             </div>
-            <div data-bind="visible: !collapsed()">
+            <div data-bind="visible: !collapsed()" role="list" data-bind="attr: {id: uid }">
                 <!-- ko foreach: cards -->
-                <a href="#" class="search-facet-item" data-bind="click: addFacet">
-                    <p class="search-facet-item-heading h4" data-bind="text: name"></p>
-                    <p class="list-group-item-text"></p>
+                <a href="#" role="button" data-bind="click: addFacet, attr: {'aria-label': 'Add ' + name + ' facet to advanced search'}" class="search-facet-item">
+                    <p data-bind="text: name"></p>
                 </a>
                 <!-- /ko -->
             </div>
+            <!-- /ko -->
             <!-- /ko -->
             <!-- /ko -->
         </div>

--- a/arches/app/templates/views/components/search/search-export.htm
+++ b/arches/app/templates/views/components/search/search-export.htm
@@ -6,7 +6,9 @@
 
     <div class="search-export">
         <div class="instruction">
-            <h2> {% trans "1. Format" %} </h2>
+            <div class="search-export-instruction-h2 h2">
+                <span> {% trans "1. Format" %} </span>
+            </div>
             <p class="container-fluid small">
                 {% trans "Select the format you'd like for your export data. (tile excel and geojson formats require a resource type filter)" %}
             </p>
@@ -43,7 +45,9 @@
         </div>
 
         <div class="instruction">
-            <h2> {% trans "2. Coordinate Precision" %} </h2>
+            <div class="search-export-instruction-h2 h2">
+                <span> {% trans "2. Coordinate Precision" %} </span>
+            </div>
             <p class="container-fluid small">
                 {% trans "Tell us how many decimal places of precision you'd like for geo-data results" %} 
             </p>
@@ -53,7 +57,9 @@
         </div>
         
         <div class="instruction">
-            <h2> {% trans "3. Report Link" %} </h2>
+            <div class="search-export-instruction-h2 h2">
+                <span> {% trans "3. Report Link" %} </span>
+            </div>
             <p class="container-fluid small">
                 {% trans "Only applicable to CSV and shapefile exports" %} 
             </p>
@@ -64,7 +70,9 @@
         <!-- ko if: ((total() > {{app_settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD}} && celeryRunning() === "True") || (format() === "html" && total() > {{app_settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD_HTML_FORMAT}} && celeryRunning() === "True")) && ("{{app_settings.RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER}}" === "False" || "{{app_settings.RESTRICT_CELERY_EXPORT_FOR_ANONYMOUS_USER}}" === "True" && "{{user.username}}" !== "anonymous")-->
         <div>
             <div class="instruction">
-                <h2>{% trans "4. Name this export" %}</h2>
+                <div class="search-export-instruction-h2 h2">
+                    <span> {% trans "4. Name this export" %} </span>
+                </div>
             </div>
             <div class="parameter">
                 <input type="" class="form-control input-md widget-input" data-bind="textInput: exportName" placeholder="Arches Export" aria-label="Name of arches export"></input>
@@ -72,7 +80,9 @@
         </div>
         <div>
             <div class="instruction">
-                <h2> {% trans "5. Email Address" %} </h2>
+                <div class="search-export-instruction-h2 h2">
+                    <span> {% trans "5. Email Address" %} </span>
+                </div>
                 <p class="container-fluid small">
                     {% trans "This download may take some time.  Tell us where to email a download link to your results" %}
                 </p>

--- a/arches/app/templates/views/components/search/search-results.htm
+++ b/arches/app/templates/views/components/search/search-results.htm
@@ -5,7 +5,7 @@
 <div id="search-results-list" data-bind="foreach: results, visible: true" style="display: none;">
 
     <div class="search-listing" data-bind="event: { mouseover: mouseoverInstance, mouseout: mouseoverInstance('')}, css: {'selected': selected()}">
-        <h3 class="search-listing-title"><a class="search-candidate-title" href="" data-bind="click: $parent.viewReport.bind($parent)"><i class="search-listing-icon" data-bind="css: iconclass"></i> <span data-bind="text: displayname"></span></a></h3>
+        <p class="search-listing-title"><a class="search-candidate-title" href="" data-bind="click: $parent.viewReport.bind($parent)"><i class="search-listing-icon" data-bind="css: iconclass"></i> <span data-bind="text: displayname"></span></a></p>
 
         <div class="search-listing-body" data-bind="html: displaydescription">
         </div>

--- a/arches/app/templates/views/components/search/time-filter.htm
+++ b/arches/app/templates/views/components/search/time-filter.htm
@@ -14,7 +14,7 @@
 
         <!-- Date Type -->
         <div class="calendar picker">
-            <h3 class="search-label">{% trans "Type" %}</h3>
+            <p class="search-label h3">{% trans "Type" %}</p>
             <select id="" class="resources" data-placeholder="Date type" tabindex="-1" data-bind="value: filter.dateNodeId, chosen:{ width: '100%' }, attr: {id:dateDropdownEleId} ">
                 <option value="">{% trans "Search all dates" %}</option>
                 <!-- ko foreach: { data: graph_models, as: 'graph' } -->
@@ -31,7 +31,7 @@
 
         <!-- Date Selector -->
         <div class="calendar picker">
-            <h3 class="search-label">{% trans "Within" %}</h3>
+            <p class="search-label h3">{% trans "Within" %}</p>
             <select id="" class="resources" placeholder="Select" tabindex="-1" data-bind="value: dateRangeType, chosen:{ width: '100%' }">
                 <option value="custom">{% trans "Custom date range" %}</option>
                 <option value="today">{% trans "Today" %}</option>
@@ -49,7 +49,7 @@
     <div id="calendar">
         <!-- From Date -->
         <div class="calendar picker">
-            <h3 class="search-label">{% trans "From" %}</h3>
+            <p class="search-label h3">{% trans "From" %}</p>
             <div id="search-from-c" class="hide-datepicker-time-option">
                 <input placeholder="" class="form-control input-md" data-bind="value: filter.fromDate, datepicker: {format: format, keepInvalid: true}, attr:{'placeholder': format}, disable: dateRangeType() !== 'custom'" aria-label="Start date">
             </div>
@@ -57,14 +57,14 @@
 
         <!-- To Date -->
         <div class="calendar picker">
-            <h3 class="search-label">{% trans "To" %}</h3>
+            <p class="search-label h3">{% trans "To" %}</p>
             <div id="search-from-b" class="hide-datepicker-time-option">
                 <input placeholder="" class="form-control input-md" data-bind="value: filter.toDate, datepicker: {format: format, keepInvalid: true}, attr:{'placeholder': format}, disable: dateRangeType() !== 'custom'" aria-label="End date">
             </div>
         </div>
     </div>
 
-    <h3 class="time-wheel-title">{% trans "Time Wheel" %}</h3>
+    <p class="time-wheel-title h3">{% trans "Time Wheel" %}</p>
     <div class="time-wheel-instructions">{% trans "(Click on a block to set a filter, double-click to zoom in, double-click center to zoom out)" %}</div>
     <hr class="title-underline"><div class="sequence" data-bind="visible: loading">{% trans 'Loading time wheel...' %}</div>
     <div class="time-wheel-wrap relative" data-bind="timeWheel: { config: wheelConfig, selectedPeriod: selectedPeriod, breadCrumb: breadCrumb}, css:{'time-wheel-loading-mask': loading}">


### PR DESCRIPTION
So that the hierarchy of headers is correct in the search page, changes the search results list item titles from h3 to p elements.

fixes [AB#71899](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/71899)