### PR TITLE
fixes github workflow error by fixing pip version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install python packages
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip<24.1"
           pip install -e .
           pip install -r arches/install/requirements.txt
           pip install -r arches/install/requirements_dev.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,16 +19,16 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
       - name: Install python packages
         run: |
           python -m pip install --upgrade "pip<24.1"
-          pip install -e .
+          pip install .
           pip install -r arches/install/requirements.txt
           pip install -r arches/install/requirements_dev.txt
           echo Python packages installed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           python-version: 3.8
 
+      - name: Install Java, GDAL, and other system dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install libxml2-dev libpq-dev openjdk-8-jdk libgdal-dev libxslt-dev
+          echo Postgres and ES dependencies installed
+
       - name: Install python packages
         run: |
           python -m pip install --upgrade "pip<24.1"
@@ -33,11 +39,6 @@ jobs:
           pip install -r arches/install/requirements_dev.txt
           echo Python packages installed
 
-      - name: Install Java, GDAL, and other system dependencies
-        run: |
-          sudo apt update
-          sudo apt-get install libxml2-dev libpq-dev openjdk-8-jdk libgdal-dev
-          echo Postgres and ES dependencies installed
 
       - uses: ankane/setup-elasticsearch@v1
         with:


### PR DESCRIPTION
Fixes github workflow error caused by pip breaking the installation of celery.

>The version reference of `pytz` used by celery 4.4.4 is `>dev`, which the older version of pip will allow, but newer ones require a version number.
