### PR TITLE
Cache busting AB#74983

### DIFF
--- a/arches/__init__.py
+++ b/arches/__init__.py
@@ -6,8 +6,6 @@ try:
 except ModuleNotFoundError as e:
     print(e)
 
-# Change this every time you release a new version
-# For example, for Keystone version 1.2.2 use VERSION = (1, 2, 2, "final", 0)
 VERSION = (6, 1, 1, "beta", 0)  # VERSION[3] options = "alpha", "beta", "rc", or "final"
 
 __version__ = get_version(VERSION)

--- a/arches/__init__.py
+++ b/arches/__init__.py
@@ -6,6 +6,8 @@ try:
 except ModuleNotFoundError as e:
     print(e)
 
+# Change this every time you release a new version
+# For example, for Keystone version 1.2.2 use VERSION = (1, 2, 2, "final", 0)
 VERSION = (6, 1, 1, "beta", 0)  # VERSION[3] options = "alpha", "beta", "rc", or "final"
 
 __version__ = get_version(VERSION)

--- a/arches/app/media/css/main.css
+++ b/arches/app/media/css/main.css
@@ -3752,7 +3752,7 @@ a.read-more:hover {
 ------------------------------------*/
 /*Main Parallax Sldier*/
 .da-slide h2 i {
-    background:url(../../plugins/parallax-slider/img/bg-heading-dark-blue.png) repeat;
+    background:url("{% static '../../plugins/parallax-slider/img/bg-heading-dark-blue.png' %}") repeat;
 }
 
 /*Sequence Parallax Sldier*/
@@ -3834,10 +3834,10 @@ a.read-more:hover {
 }
 
 .bx-wrapper .bx-prev {
-    background-image: url(../../plugins/bxslider/images/controls-dark-blue.png);
+    background-image: url("{% static '../../plugins/bxslider/images/controls-dark-blue.png' %}");
 }
 .bx-wrapper .bx-next {
-    background-image: url(../../plugins/bxslider/images/controls-dark-blue.png);
+    background-image: url("{% static '../../plugins/bxslider/images/controls-dark-blue.png' %}");
 }
 
 /*Typography

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -7,7 +7,7 @@
     var CKEDITOR_BASEPATH = '{{ STATIC_URL }}packages/ckeditor/';
     require.config({
         baseUrl: '{{ STATIC_URL }}js',
-        urlArgs: '_dc={{ app_settings.VERSION }}',
+        urlArgs: '_dc={{ app_settings.SOFTWARE_VERSION }}',
         paths: {
             'plugins': '{{ STATIC_URL }}plugins',
             'widget-templates': '{% url "widgets" ""%}'.replace(/\/$/, ""),

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -7,7 +7,7 @@
     var CKEDITOR_BASEPATH = '{{ STATIC_URL }}packages/ckeditor/';
     require.config({
         baseUrl: '{{ STATIC_URL }}js',
-        urlArgs: '_dc={{ app_settings.SOFTWARE_VERSION }}',
+        urlArgs: '_dc={{ app_settings.APP_VERSION|default_if_none:app_settings.VERSION }}',
         paths: {
             'plugins': '{{ STATIC_URL }}plugins',
             'widget-templates': '{% url "widgets" ""%}'.replace(/\/$/, ""),

--- a/arches/app/utils/context_processors.py
+++ b/arches/app/utils/context_processors.py
@@ -23,6 +23,11 @@ from arches.app.models.system_settings import settings
 from arches.app.utils.geo_utils import GeoUtils
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.views.search import allow_user_to_export_results
+from arches.setup import get_version
+try:
+    from arches_her import __software_version__
+except:
+    __software_version__ = None
 
 
 def livereload(request):
@@ -32,14 +37,17 @@ def livereload(request):
 def map_info(request):
     geo_utils = GeoUtils()
     if settings.DEFAULT_BOUNDS is not None:
-        hex_bin_bounds = geo_utils.get_bounds_from_geojson(settings.DEFAULT_BOUNDS)
+        hex_bin_bounds = geo_utils.get_bounds_from_geojson(
+            settings.DEFAULT_BOUNDS)
         default_center = geo_utils.get_centroid(settings.DEFAULT_BOUNDS)
     else:
         hex_bin_bounds = (0, 0, 1, 1)
-        default_center = {"coordinates": [6.602384, 0.245926]}  # an island off the coast of Africa
+        # an island off the coast of Africa
+        default_center = {"coordinates": [6.602384, 0.245926]}
 
     try:
-        group_map_settings = GroupMapSettings.objects.get(group=request.user.groups.all()[0])
+        group_map_settings = GroupMapSettings.objects.get(
+            group=request.user.groups.all()[0])
         min_zoom = group_map_settings.min_zoom
         max_zoom = group_map_settings.max_zoom
         default_zoom = group_map_settings.default_zoom
@@ -54,7 +62,8 @@ def map_info(request):
             "zoom": default_zoom,
             "map_min_zoom": min_zoom,
             "map_max_zoom": max_zoom,
-            "map_search_auto_zoom" : "true" if settings.MAP_SEARCH_AUTO_ZOOM else "false", # needs to be set from the settings and to be added to the System Settings Graph so it can be changed by the sys admin
+            # needs to be set from the settings and to be added to the System Settings Graph so it can be changed by the sys admin
+            "map_search_auto_zoom": "true" if settings.MAP_SEARCH_AUTO_ZOOM else "false",
             "mapbox_api_key": settings.MAPBOX_API_KEY,
             "hex_bin_size": settings.HEX_BIN_SIZE if settings.HEX_BIN_SIZE is not None else 100,
             "mapbox_sprites": settings.MAPBOX_SPRITES,
@@ -70,6 +79,7 @@ def app_settings(request):
     return {
         "app_settings": {
             "VERSION": __version__,
+            "SOFTWARE_VERSION": __software_version__ if __software_version__ else __version__,
             "APP_NAME": settings.APP_NAME,
             "GOOGLE_ANALYTICS_TRACKING_ID": settings.GOOGLE_ANALYTICS_TRACKING_ID,
             "USE_SEMANTIC_RESOURCE_RELATIONSHIPS": settings.USE_SEMANTIC_RESOURCE_RELATIONSHIPS,

--- a/arches/app/utils/context_processors.py
+++ b/arches/app/utils/context_processors.py
@@ -24,10 +24,6 @@ from arches.app.utils.geo_utils import GeoUtils
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.views.search import allow_user_to_export_results
 from arches.setup import get_version
-try:
-    from arches_her import __software_version__
-except:
-    __software_version__ = None
 
 
 def livereload(request):

--- a/arches/app/utils/context_processors.py
+++ b/arches/app/utils/context_processors.py
@@ -23,7 +23,6 @@ from arches.app.models.system_settings import settings
 from arches.app.utils.geo_utils import GeoUtils
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.views.search import allow_user_to_export_results
-from arches.setup import get_version
 
 
 def livereload(request):

--- a/arches/app/utils/context_processors.py
+++ b/arches/app/utils/context_processors.py
@@ -77,7 +77,7 @@ def app_settings(request):
     return {
         "app_settings": {
             "VERSION": __version__,
-            "SOFTWARE_VERSION": __software_version__ if __software_version__ else __version__,
+            "APP_VERSION": settings.APP_VERSION,
             "APP_NAME": settings.APP_NAME,
             "GOOGLE_ANALYTICS_TRACKING_ID": settings.GOOGLE_ANALYTICS_TRACKING_ID,
             "USE_SEMANTIC_RESOURCE_RELATIONSHIPS": settings.USE_SEMANTIC_RESOURCE_RELATIONSHIPS,

--- a/arches/app/utils/context_processors.py
+++ b/arches/app/utils/context_processors.py
@@ -37,8 +37,7 @@ def livereload(request):
 def map_info(request):
     geo_utils = GeoUtils()
     if settings.DEFAULT_BOUNDS is not None:
-        hex_bin_bounds = geo_utils.get_bounds_from_geojson(
-            settings.DEFAULT_BOUNDS)
+        hex_bin_bounds = geo_utils.get_bounds_from_geojson(settings.DEFAULT_BOUNDS)
         default_center = geo_utils.get_centroid(settings.DEFAULT_BOUNDS)
     else:
         hex_bin_bounds = (0, 0, 1, 1)
@@ -46,8 +45,7 @@ def map_info(request):
         default_center = {"coordinates": [6.602384, 0.245926]}
 
     try:
-        group_map_settings = GroupMapSettings.objects.get(
-            group=request.user.groups.all()[0])
+        group_map_settings = GroupMapSettings.objects.get(group=request.user.groups.all()[0])
         min_zoom = group_map_settings.min_zoom
         max_zoom = group_map_settings.max_zoom
         default_zoom = group_map_settings.default_zoom

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -571,6 +571,7 @@ DEFAULT_GEOCODER = "10000000-0000-0000-0000-010000000000"
 SPARQL_ENDPOINT_PROVIDERS = ({"SPARQL_ENDPOINT_PROVIDER": "arches.app.utils.data_management.sparql_providers.aat_provider.AAT_Provider"},)
 
 APP_NAME = "Arches"
+APP_VERSION = None
 
 APP_TITLE = "Arches | Heritage Data Management"
 COPYRIGHT_TEXT = "All Rights Reserved."


### PR DESCRIPTION
[AB#74983](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/74983)

Fix image references to use {% static %} and add comment on how to increment version number when deploying. Cache busting using NonStrictManifestStaticFilesStorage relies on assets referenced in CSS files to have {% static %}. In addition, assets served with _dc=6.1.1b0 suffixed to the filename will going forward need to be updated to reflect the version number of Keystone e.g. _dc=1.2.2. Instructions added to __init__.py.