### PR TITLE
Fix requirements.txt

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.2.21
-psycopg2==2.9.6
+psycopg2-binary==2.8.4
 elasticsearch>=8.3.1,<9.0.0
 rdflib==4.2.2
 django-guardian==2.3.0

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -1,5 +1,6 @@
 Django==3.2.21
-psycopg2==2.9.6elasticsearch>=8.3.1,<9.0.0
+psycopg2==2.9.6
+elasticsearch>=8.3.1,<9.0.0
 rdflib==4.2.2
 django-guardian==2.3.0
 python-memcached==1.59


### PR DESCRIPTION
Bad merge resulted in the following line getting created:

`psycopg2==2.9.6elasticsearch>=8.3.1,<9.0.0`

This has been updated to:

```
psycopg2==2.9.6
elasticsearch>=8.3.1,<9.0.0
```