### PR TITLE
AB#78249 Ensure adv search facet labels appear after page refresh

### DIFF
--- a/arches/app/media/js/views/components/search/advanced-search.js
+++ b/arches/app/media/js/views/components/search/advanced-search.js
@@ -173,8 +173,7 @@ define([
                             self.applyNodeOrderAndLabels(card);
                             _.each(card.nodes, function(node) {
                                 facet[node.nodeid] = ko.observable(facet[node.nodeid]);
-                                node.label = node.name;
-                            }).sort((a, b) => a.sortorder - b.sortorder);
+                            });
                             facet.op = ko.observable(facet.op);
                             this.filter.facets.push({
                                 card: card,

--- a/arches/app/media/js/views/components/search/advanced-search.js
+++ b/arches/app/media/js/views/components/search/advanced-search.js
@@ -50,17 +50,7 @@ define([
                             return node.nodegroup_id === card.nodegroup_id;
                         });
                         card.addFacet = function() {
-                            _.each(card.nodes, function(node) {
-                                if (self.cardNameDict[node.nodegroup_id] && node.nodeid === node.nodegroup_id) {
-                                    node.label = self.cardNameDict[node.nodegroup_id];
-                                } else if (node.nodeid !== node.nodegroup_id && self.widgetLookup[node.nodeid]) {
-                                    const widget = self.widgetLookup[node.nodeid];
-                                    node.label = widget.label;
-                                    node.sortorder = widget.sortorder;
-                                } else {
-                                    node.label = node.name;
-                                }
-                            }).sort((a, b) => a.sortorder - b.sortorder);
+                            self.applyNodeOrderAndLabels(card);
                             self.newFacet(card);
                         };
                     }, this);
@@ -145,7 +135,23 @@ define([
                 this.filter.facets.push(facet);
             },
 
+            applyNodeOrderAndLabels: function(card){
+                var self = this;
+                _.each(card.nodes, function(node) {
+                    if (self.cardNameDict[node.nodegroup_id] && node.nodeid === node.nodegroup_id) {
+                        node.label = self.cardNameDict[node.nodegroup_id];
+                    } else if (node.nodeid !== node.nodegroup_id && self.widgetLookup[node.nodeid]) {
+                        const widget = self.widgetLookup[node.nodeid];
+                        node.label = widget.label;
+                        node.sortorder = widget.sortorder;
+                    } else {
+                        node.label = node.name;
+                    }
+                }).sort((a, b) => a.sortorder - b.sortorder);
+            },
+
             restoreState: function() {
+                var self = this;
                 var query = this.query();
                 if (componentName in query) {
                     var facets = JSON.parse(query[componentName]);
@@ -164,6 +170,7 @@ define([
                             return _.contains(cardNodeIds, nodeIds[0]);
                         }, this);
                         if (card) {
+                            self.applyNodeOrderAndLabels(card);
                             _.each(card.nodes, function(node) {
                                 facet[node.nodeid] = ko.observable(facet[node.nodeid]);
                                 node.label = node.name;

--- a/arches/app/media/js/views/components/search/advanced-search.js
+++ b/arches/app/media/js/views/components/search/advanced-search.js
@@ -167,7 +167,7 @@ define([
                             _.each(card.nodes, function(node) {
                                 facet[node.nodeid] = ko.observable(facet[node.nodeid]);
                                 node.label = node.name;
-                            });
+                            }).sort((a, b) => a.sortorder - b.sortorder);
                             facet.op = ko.observable(facet.op);
                             this.filter.facets.push({
                                 card: card,

--- a/arches/app/media/js/views/components/search/advanced-search.js
+++ b/arches/app/media/js/views/components/search/advanced-search.js
@@ -166,6 +166,7 @@ define([
                         if (card) {
                             _.each(card.nodes, function(node) {
                                 facet[node.nodeid] = ko.observable(facet[node.nodeid]);
+                                node.label = node.name;
                             });
                             facet.op = ko.observable(facet.op);
                             this.filter.facets.push({


### PR DESCRIPTION
Ensure the advanced search facet labels display when having previously selected a few and then refresh the page.