### PR TITLE
AB#81729 Remove red outlines on fields in locations card for monuments

### DIFF
--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -326,7 +326,7 @@
             {% block form_cards %}
             <ul class="card-summary-section" data-bind="css: {disabled: !tile.tileid}">
                 <!-- ko foreach: { data: tile.cards, as: 'card' } -->
-                <li style="border:1px solid red;" class="card-summary" data-bind="visible: card.model.visible()">
+                <li class="card-summary" data-bind="visible: card.model.visible()">
                     <a href="#" data-bind="click: function () {
                         if (card.parent.tileid) {
                             card.canAdd() ? card.selected(true) : card.tiles()[0].selected(true);


### PR DESCRIPTION
This fix removes the red outlines on fields in the locations card for monuments