### PR TITLE
Keystone/release 1.2.4 into main

### DIFF
--- a/arches/app/media/js/views/components/search/advanced-search.js
+++ b/arches/app/media/js/views/components/search/advanced-search.js
@@ -50,15 +50,7 @@ define([
                             return node.nodegroup_id === card.nodegroup_id;
                         });
                         card.addFacet = function() {
-                            _.each(card.nodes, function(node) {
-                                if (self.cardNameDict[node.nodegroup_id] && node.nodeid === node.nodegroup_id) {
-                                    node.label = self.cardNameDict[node.nodegroup_id];
-                                } else if (node.nodeid !== node.nodegroup_id && self.widgetLookup[node.nodeid]) {
-                                    node.label = self.widgetLookup[node.nodeid].label;
-                                } else {
-                                    node.label = node.name;
-                                }
-                            });
+                            self.applyNodeOrderAndLabels(card);
                             self.newFacet(card);
                         };
                     }, this);
@@ -143,7 +135,23 @@ define([
                 this.filter.facets.push(facet);
             },
 
+            applyNodeOrderAndLabels: function(card){
+                var self = this;
+                _.each(card.nodes, function(node) {
+                    if (self.cardNameDict[node.nodegroup_id] && node.nodeid === node.nodegroup_id) {
+                        node.label = self.cardNameDict[node.nodegroup_id];
+                    } else if (node.nodeid !== node.nodegroup_id && self.widgetLookup[node.nodeid]) {
+                        const widget = self.widgetLookup[node.nodeid];
+                        node.label = widget.label;
+                        node.sortorder = widget.sortorder;
+                    } else {
+                        node.label = node.name;
+                    }
+                }).sort((a, b) => a.sortorder - b.sortorder);
+            },
+
             restoreState: function() {
+                var self = this;
                 var query = this.query();
                 if (componentName in query) {
                     var facets = JSON.parse(query[componentName]);
@@ -162,6 +170,7 @@ define([
                             return _.contains(cardNodeIds, nodeIds[0]);
                         }, this);
                         if (card) {
+                            self.applyNodeOrderAndLabels(card);
                             _.each(card.nodes, function(node) {
                                 facet[node.nodeid] = ko.observable(facet[node.nodeid]);
                             });

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -6,6 +6,7 @@
 <script>
     var CKEDITOR_BASEPATH = '{{ STATIC_URL }}packages/ckeditor/';
     require.config({
+        waitSeconds: 45,
         baseUrl: '{{ STATIC_URL }}js',
         urlArgs: '_dc={{ app_settings.APP_VERSION|default_if_none:app_settings.VERSION }}',
         paths: {

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -326,7 +326,7 @@
             {% block form_cards %}
             <ul class="card-summary-section" data-bind="css: {disabled: !tile.tileid}">
                 <!-- ko foreach: { data: tile.cards, as: 'card' } -->
-                <li style="border:1px solid red;" class="card-summary" data-bind="visible: card.model.visible()">
+                <li class="card-summary" data-bind="visible: card.model.visible()">
                     <a href="#" data-bind="click: function () {
                         if (card.parent.tileid) {
                             card.canAdd() ? card.selected(true) : card.tiles()[0].selected(true);


### PR DESCRIPTION
Merge for release 1.2.4, includes the following changes:

81729 - All the fields are outlined in red in the edit monument locations section
78253 - Fix issue found where Advanced Search is restored and the facet labels don't appear
78890 - Add require.js waitSeconds to stop the front end from timing out
