### PR TITLE
AB#81499 Add link to new typekit font css

### DIFF
--- a/arches/app/templates/base.htm
+++ b/arches/app/templates/base.htm
@@ -53,6 +53,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         {% endif %}
         <link href="{% static 'css/package.css' %}" rel="stylesheet">
         <link href="{% static 'css/project.css' %}" rel="stylesheet">
+        <link rel="stylesheet" type="text/css" href="https://use.typekit.net/hkz3ptw.css" />
     {% endblock css%}
 
     <script type="text/javascript">


### PR DESCRIPTION
This change adds a new <head> css link for the new branding font.

This PR is to be done in conjunction with [this Arches-Her PR](https://github.com/HistoricEngland/arches-her/pull/362)

Fixes [81499](https://dev.azure.com/hedev/Inventory/_sprints/taskboard/Inventory/Inventory/Inventory/Sprint%20118?workitem=81499)